### PR TITLE
Improve tests adding mutmut and enhancing coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,10 @@ jobs:
       - *setup-python
       # Install dependencies
       - *install-dependencies
+      # Install test dependencies
+      - &install-test-dependencies
+        name: Install test dependencies
+        run: pip install -r requirements.test.txt
       # Run tests with coverage
       - name: Run pytest
         run: pytest --cov-branch
@@ -57,13 +61,15 @@ jobs:
       - *setup-python
       # Install dependencies
       - *install-dependencies
+      # Install test dependencies
+      - *install-test-dependencies
       # Run mutation tests
       - name: Run mutmut (mutation tests)
         env:
           MPLBACKEND: Agg
           PYTHONPATH: "${{ github.workspace }}/src"
         run: |
-          mutmut run --max-children 1
+          mutmut run
       # Show mutmut results
       - name: Show mutmut results
         run: mutmut results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,43 +4,66 @@ on:
   push:
 
 jobs:
-  ruff:
-    name: "Ruff"
+  lint-and-format:
+    name: "Lint & Format"
     runs-on: "ubuntu-latest"
     steps:
-        - name: "Checkout the repository"
+        # Checkout the repository
+        - &checkout
+          name: "Checkout the repository"
           uses: "actions/checkout@v5.0.0"
-        - name: "Set up Python"
+        # Set up Python
+        - &setup-python
+          name: "Set up Python"
           uses: "actions/setup-python@v5.6.0"
           with:
             python-version: "3.12"
             cache: "pip"
-        - name: "Install dependencies"
+        # Install dependencies and run linter and formatter
+        - &install-dependencies
+          name: "Install dependencies"
           run: pip install -r requirements.txt
+        # Run linter 
         - name: "Lint"
           run: python3 -m ruff check .
+        # Run formatter in check mode
         - name: "Format"
           run: python3 -m ruff format . --check
-  test:
-    name: "Test"
+  unit-test:
+    name: "Unit Test"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Checkout the repository"
-        uses: "actions/checkout@v5.0.0"
-      - name: "Set up Python"
-        uses: "actions/setup-python@v5.6.0"
-        with:
-          python-version: "3.12"
-          cache: "pip"
-      - name: Install dependencies
-        run: pip install -r requirements.test.txt -r requirements.txt
+      # Checkout the repository
+      - *checkout
+      # Set up Python
+      - *setup-python
+      # Install dependencies
+      - *install-dependencies
+      # Run tests with coverage
       - name: Run pytest
         run: pytest --cov-branch
+      # Upload coverage reports to Codecov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+  mutation-test:
+    name: "Mutation Test"
+    runs-on: "ubuntu-latest"
+    steps:
+      # Run mutation tests with mutmut
+      - *checkout
+      # Set up Python
+      - *setup-python
+      # Install dependencies
+      - *install-dependencies
+      # Run mutation tests
       - name: Run mutmut (mutation tests)
         env:
           MPLBACKEND: Agg
           PYTHONPATH: "${{ github.workspace }}/src"
         run: |
           mutmut run --max-children 1
+      # Show mutmut results
       - name: Show mutmut results
         run: mutmut results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,10 @@ jobs:
         run: pip install -r requirements.test.txt -r requirements.txt
       - name: Run pytest
         run: pytest --cov-branch
+      - name: Run mutmut (mutation tests)
+        env:
+          MPLBACKEND: Agg
+        run: |
+          mutmut run --max-children 1
+      - name: Show mutmut results
+        run: mutmut results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Run mutmut (mutation tests)
         env:
           MPLBACKEND: Agg
+          PYTHONPATH: "${{ github.workspace }}/src"
         run: |
           mutmut run --max-children 1
       - name: Show mutmut results

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.11.2"
+    rev: "v0.12.11"
     hooks:
       # Run the linter
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,11 @@ repos:
         args: [ --fix ]
       # Run the formatter
       - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,27 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # Ruff version.
-    rev: "v0.12.11"
-    hooks:
-      # Run the linter
-      - id: ruff
-        args: [ --fix ]
-      # Run the formatter
-      - id: ruff-format
-
   - repo: local
     hooks:
+      - id: ruff-lint
+        name: Ruff linter
+        entry: ruff check --fix
+        language: system
+        pass_filenames: false
+
+      - id: ruff-format
+        name: Ruff formatter
+        entry: ruff format
+        language: system
+        pass_filenames: false
+
       - id: pytest
         name: pytest
         entry: pytest -q
         language: system
         pass_filenames: false
+
+      - id: mutmut
+        name: Mutmut mutation tests
+        entry: mutmut run
+        language: system
+        pass_filenames: false
+        exclude: ^mutants/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 # SignalBridge - Test Suite
 
 [![Tests](https://github.com/carlosmazzei/signalbridge-test-suite/actions/workflows/lint.yml/badge.svg)](https://github.com/carlosmazzei/signalbridge-test-suite/actions/workflows/lint.yml)
+[![Coverage](https://codecov.io/gh/carlosmazzei/signalbridge-test-suite/branch/main/graph/badge.svg)](https://codecov.io/gh/carlosmazzei/signalbridge-test-suite)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 testpaths = tests
+pythonpath = src
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .git

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ paths_to_mutate =
     src/application_manager.py
     src/checksum.py
     src/visualize_results.py
-runner = env MPLBACKEND=Agg python -m pytest -q -o addopts=
+runner = python -m pytest -q -o addopts=
 
 tests_dir = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[mutmut]
+paths_to_mutate =
+    src/application_manager.py
+    src/checksum.py
+    src/visualize_results.py
+runner = python -m pytest -q
+
+tests_dir = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,6 @@ paths_to_mutate =
     src/application_manager.py
     src/checksum.py
     src/visualize_results.py
-runner = python -m pytest -q
+runner = env MPLBACKEND=Agg python -m pytest -q -o addopts=
 
 tests_dir = tests

--- a/src/visualize_results.py
+++ b/src/visualize_results.py
@@ -185,6 +185,7 @@ class VisualizeResults:
                 figsize=(10, 8),
                 gridspec_kw={"height_ratios": [2, 1]},
                 sharex=True,
+                constrained_layout=True,
             )
 
             fig.suptitle(f"Test Results Visualization (jitter = {jitter})", fontsize=12)
@@ -253,7 +254,6 @@ class VisualizeResults:
             ax2.grid(axis="y", linestyle="--", alpha=0.7)
             plt.setp(ax2.get_xticklabels(), rotation=45, ha="right")
 
-            plt.tight_layout()
             plt.show()
 
         except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,22 @@
 """Configuration for pytest."""
 
+import os
 import sys
 from pathlib import Path
+
+# Ensure headless matplotlib backend for CI/mutation runs
+os.environ.setdefault("MPLBACKEND", "Agg")
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:  # Best effort: force Agg before any pyplot import
+    import matplotlib as mpl
+
+    mpl.use("Agg", force=True)  # type: ignore[call-arg]
+except (ImportError, AttributeError):
+    # If matplotlib isn't installed or already configured, log the exception
+    logger.exception("Could not configure matplotlib backend.")
 
 # Add the src directory to Python's path
 src_path = Path(__file__).parent.parent / "src"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,18 @@ except (ImportError, AttributeError):
     # If matplotlib isn't installed or already configured, log the exception
     logger.exception("Could not configure matplotlib backend.")
 
-# Add the src directory to Python's path
-src_path = Path(__file__).parent.parent / "src"
-sys.path.insert(0, str(src_path))
+
+# Add the src directory to Python's path, robust across mutmut's mutants tree
+def _find_src_dir(start: Path, max_up: int = 6) -> Path | None:
+    p = start.resolve()
+    for _ in range(max_up):
+        candidate = p / "src"
+        if candidate.exists():
+            return candidate
+        p = p.parent
+    return None
+
+
+src_dir = _find_src_dir(Path(__file__).parent)
+if src_dir:
+    sys.path.insert(0, str(src_dir))

--- a/tests/test_application_manager.py
+++ b/tests/test_application_manager.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time as _time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -33,6 +33,13 @@ def app_manager(mock_serial: SerialInterface) -> ApplicationManager:
     return ApplicationManager("COM1", 115200, 1.0)
 
 
+def test_app_manager_constructs_serial_with_params() -> None:
+    """Constructor should pass through serial params to SerialInterface."""
+    with patch("application_manager.SerialInterface") as serial_cls:
+        _ = ApplicationManager("PORTX", 57600, 0.25)
+        serial_cls.assert_called_once_with("PORTX", 57600, 0.25)
+
+
 def test_initialization(app_manager: ApplicationManager) -> None:
     """Test the initial state of ApplicationManager."""
     assert app_manager.mode == Mode.IDLE
@@ -44,7 +51,8 @@ def test_initialize_success(
     app_manager: ApplicationManager, mock_serial: SerialInterface
 ) -> None:
     """Test successful initialization when serial opens."""
-    mock_serial.open.return_value = True
+    ms = cast("Mock", mock_serial)
+    ms.open.return_value = True
     result = app_manager.initialize()
     assert result is True
     assert set(app_manager.modules) == {
@@ -54,8 +62,8 @@ def test_initialize_success(
         Mode.REGRESSION,
         Mode.STATUS,
     }
-    mock_serial.set_message_handler.assert_called_once()
-    mock_serial.start_reading.assert_called_once()
+    ms.set_message_handler.assert_called_once()
+    ms.start_reading.assert_called_once()
     app_manager.cleanup()
 
 
@@ -63,19 +71,37 @@ def test_initialize_failure(
     app_manager: ApplicationManager, mock_serial: SerialInterface
 ) -> None:
     """Test initialization when serial interface fails to open."""
-    mock_serial.open.return_value = False
+    ms = cast("Mock", mock_serial)
+    ms.open.return_value = False
     result = app_manager.initialize()
     assert result is False
     assert set(app_manager.modules) == {Mode.VISUALIZE}
-    mock_serial.set_message_handler.assert_not_called()
-    mock_serial.start_reading.assert_not_called()
+    ms.set_message_handler.assert_not_called()
+    ms.start_reading.assert_not_called()
     app_manager.cleanup()
 
 
 def test_cleanup(app_manager: ApplicationManager, mock_serial: SerialInterface) -> None:
     """Test cleanup closes the serial interface."""
     app_manager.cleanup()
-    mock_serial.close.assert_called_once()
+    ms = cast("Mock", mock_serial)
+    ms.close.assert_called_once()
+
+
+def test_disconnect_serial_clears_serial_modules(
+    app_manager: ApplicationManager, mock_serial: SerialInterface
+) -> None:
+    """disconnect_serial closes port and removes only serial-required modules."""
+    # Prime modules with a serial-required and a non-serial one
+    app_manager.modules = {Mode.VISUALIZE: object(), Mode.LATENCY: object()}
+    ms = cast("Mock", mock_serial)
+    ms.is_open.return_value = True
+    app_manager.disconnect_serial()
+    ms.close.assert_called()
+    assert Mode.LATENCY not in app_manager.modules
+    assert Mode.VISUALIZE in app_manager.modules
+    assert app_manager.mode == Mode.IDLE
+    assert app_manager.connected is False
 
 
 @pytest.mark.parametrize(
@@ -111,6 +137,35 @@ def test_display_menu_all_modules(
     for cfg in app_manager.module_configs:
         assert f"{cfg.key}. {cfg.description}" in out
     assert f"{app_manager.exit_key}. Exit" in out
+
+
+def test_app_manager_initial_mode_and_exit_key() -> None:
+    """Ensure constructor sets mode and exit key deterministically."""
+    with patch("application_manager.SerialInterface"):
+        am = ApplicationManager("P", 9600, 0.1)
+    assert am.mode == Mode.IDLE
+    assert am.exit_key == "6"  # keys 1..5 defined above, exit is last+1
+
+
+def test_display_menu_contains_expected_labels(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Menu text should contain the static labels for each option."""
+    with patch("application_manager.SerialInterface"):
+        am = ApplicationManager("P", 9600, 0.1)
+    # Make all modules available
+    for cfg in am.module_configs:
+        am.modules[cfg.mode] = object()
+    am.connected = True
+    am.display_menu()
+    out = capsys.readouterr().out
+    assert "0. Disconnect from device" in out
+    assert "1. Run latency test" in out
+    assert "2. Send command" in out
+    assert "3. Regression test" in out
+    assert "4. Visualize test results" in out
+    assert "5. Status mode" in out
+    assert f"{am.exit_key}. Exit" in out
 
 
 def test_display_menu_some_modules(
@@ -286,7 +341,8 @@ def test_monitor_connection_triggers_disconnect(
 ) -> None:
     """Monitor thread should disconnect if port closes."""
     app_manager.connected = True
-    mock_serial.is_open.return_value = False
+    ms = cast("Mock", mock_serial)
+    ms.is_open.return_value = False
 
     with patch.object(app_manager, "disconnect_serial") as mock_disconnect:
         app_manager.monitor_stop_event.clear()

--- a/tests/test_application_manager.py
+++ b/tests/test_application_manager.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+import time as _time
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
@@ -283,9 +285,6 @@ def test_monitor_connection_triggers_disconnect(
     mock_serial: SerialInterface,
 ) -> None:
     """Monitor thread should disconnect if port closes."""
-    import threading
-    import time as _time
-
     app_manager.connected = True
     mock_serial.is_open.return_value = False
 

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,6 +1,6 @@
 """Tests for the checksum module."""
 
-from src.checksum import calculate_checksum
+from checksum import calculate_checksum
 
 
 def test_empty_data() -> None:

--- a/tests/test_latency_test.py
+++ b/tests/test_latency_test.py
@@ -1,0 +1,352 @@
+"""Unit tests for src/latency_test.py."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from latency_test import (
+    DEFAULT_MESSAGE_LENGTH,
+    DEFAULT_SAMPLES,
+    DEFAULT_WAIT_TIME,
+    HEADER_BYTES,
+    LatencyTest,
+)
+from serial_interface import SerialCommand, SerialInterface
+
+
+@pytest.fixture
+def latency_tester() -> LatencyTest:
+    """LatencyTest with a mocked SerialInterface."""
+    ser = Mock(spec=SerialInterface)
+    return LatencyTest(ser)
+
+
+def test_publish_builds_correct_payload_and_records_time(
+    latency_tester: LatencyTest,
+) -> None:
+    """publish() should build a properly formatted payload and call write()."""
+    ser_mock: Mock = latency_tester.ser  # type: ignore[assignment]
+
+    counter = 5
+    message_length = 8
+
+    with patch("latency_test.time.perf_counter", return_value=123.456):
+        latency_tester.publish(counter, message_length)
+
+    # Verify time recorded
+    assert pytest.approx(latency_tester.latency_msg_sent[counter]) == pytest.approx(
+        123.456
+    )
+
+    # Verify payload structure sent to serial
+    assert ser_mock.write.call_count == 1
+    (payload,), _ = ser_mock.write.call_args
+    assert isinstance(payload, (bytes, bytearray))
+    assert len(payload) == message_length
+    # Header
+    assert payload[:2] == HEADER_BYTES
+    # Length byte equals trailer length + 2 (for 2-byte counter)
+    expected_trailer_len = message_length - len(HEADER_BYTES) - 3
+    assert payload[2] == expected_trailer_len + 2
+    # Counter bytes (big-endian)
+    assert payload[3:5] == counter.to_bytes(2, "big")
+    # Trailer is 0x02 pattern
+    assert payload[5:] == bytes([0x02] * expected_trailer_len)
+
+
+def test_calculate_test_results_with_data(latency_tester: LatencyTest) -> None:
+    """_calculate_test_results returns stats when results exist."""
+    # Pre-populate received latencies
+    latency_tester.latency_msg_sent = {0: 0.0, 1: 0.0, 2: 0.0}
+    latency_tester.latency_msg_received = {0: 0.10, 1: 0.20, 2: 0.30}
+
+    ptest = 1
+    psamples = 3
+    pwaiting_time = 0.05
+    pbitrate = 100.0
+    pjitter = True
+
+    res = latency_tester._calculate_test_results(
+        test=ptest,
+        samples=psamples,
+        waiting_time=pwaiting_time,
+        bitrate=pbitrate,
+        jitter=pjitter,
+    )
+
+    assert res["test"] == ptest
+    assert res["samples"] == psamples
+    assert res["waiting_time"] == pytest.approx(pwaiting_time)
+    assert res["jitter"] is pjitter
+    assert res["bitrate"] == pytest.approx(pbitrate)
+    assert res["dropped_messages"] == 0
+    assert pytest.approx(res["latency_avg"], rel=1e-6) == pytest.approx(
+        np.mean([0.10, 0.20, 0.30])
+    )
+    assert res["latency_min"] == pytest.approx(0.10)
+    assert res["latency_max"] == pytest.approx(0.30)
+    assert pytest.approx(res["latency_p95"], rel=1e-6) == pytest.approx(
+        float(np.percentile([0.10, 0.20, 0.30], 95))
+    )
+
+
+def test_calculate_test_results_no_data(latency_tester: LatencyTest) -> None:
+    """_calculate_test_results handles empty results and reports drops."""
+    # Simulate that 3 messages were sent but none received
+    latency_tester.latency_msg_sent = {0: 0.0, 1: 0.0, 2: 0.0}
+    latency_tester.latency_msg_received = {}
+
+    res = latency_tester._calculate_test_results(
+        test=0, samples=3, waiting_time=0.1, bitrate=50.0, jitter=False
+    )
+
+    assert res == {
+        "test": 0,
+        "waiting_time": 0.1,
+        "samples": 3,
+        "latency_avg": 0,
+        "latency_min": 0,
+        "latency_max": 0,
+        "latency_p95": 0,
+        "jitter": False,
+        "bitrate": 50.0,
+        "dropped_messages": 3,
+    }
+
+
+def test_write_output_to_file_success(tmp_path: Path) -> None:
+    """_write_output_to_file writes JSON data to the given path."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+    output_file = tmp_path / "out.json"
+    payload = [{"a": 1}, {"b": 2}]
+
+    tester._write_output_to_file(output_file, payload)
+
+    assert output_file.exists()
+    data = json.loads(output_file.read_text())
+    assert data == payload
+
+
+def test_write_output_to_file_oserror_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """_write_output_to_file logs exceptions when file writing fails."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+    bad_path = Path("/cannot/open/this.json")
+
+    with (
+        patch.object(Path, "open", side_effect=OSError),
+        caplog.at_level(logging.ERROR),
+    ):
+        logger = logging.getLogger("latency_test")
+        logger.addHandler(caplog.handler)
+        tester._write_output_to_file(bad_path, [{"x": 1}])
+        logger.removeHandler(caplog.handler)
+    assert "Error writing to file." in caplog.text
+
+
+def test_handle_message_valid_updates_latency(latency_tester: LatencyTest) -> None:
+    """handle_message computes latency and stores it by counter."""
+    counter = 7
+    # Simulate that the message with this counter was sent at t=1.0
+    latency_tester.latency_msg_sent[counter] = 1.0
+
+    # perf_counter now returns 2.5, so latency should be 1.5
+    with patch("latency_test.time.perf_counter", return_value=2.5):
+        latency_tester.handle_message(
+            SerialCommand.ECHO_COMMAND.value, b"\x00\x00\x00\x00\x07"
+        )
+
+    assert pytest.approx(latency_tester.latency_msg_received[counter]) == pytest.approx(
+        1.5
+    )
+
+
+def test_handle_message_index_error_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """handle_message logs on malformed data (IndexError)."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("latency_test")
+        logger.addHandler(caplog.handler)
+        tester.handle_message(SerialCommand.ECHO_COMMAND.value, b"\x01\x02")
+        logger.removeHandler(caplog.handler)
+    assert "Invalid message (Index Error)" in caplog.text
+
+
+def test_get_user_input_default_and_casting() -> None:
+    """_get_user_input returns default on blank and casts otherwise."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+    with patch("builtins.input", return_value=" "):
+        pinput = 3
+        assert tester._get_user_input("prompt", pinput) == pinput
+    with patch("builtins.input", return_value="7"):
+        preturn = 7
+        assert tester._get_user_input("prompt", pinput) == preturn
+    with patch("builtins.input", return_value="1.5"):
+        assert pytest.approx(tester._get_user_input("prompt", 0.5)) == pytest.approx(
+            1.5
+        )
+
+
+def test_show_options_happy_path() -> None:
+    """_show_options converts ms inputs to seconds and validates ranges."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+    with patch.object(
+        LatencyTest,
+        "_get_user_input",
+        side_effect=[2, 100, 200, 10, 1, True, 6],
+    ):
+        res = tester._show_options()
+    # Param: num_times, min_wait(s), max_wait(s), samples, wait_time(s), jitter, msg_len
+    assert res == (2, 0.1, 0.2, 10, 1, True, 6)
+
+
+def test_show_options_invalid_values(caplog: pytest.LogCaptureFixture) -> None:
+    """_show_options falls back to defaults on invalid values."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+
+    with (
+        patch.object(
+            LatencyTest,
+            "_get_user_input",
+            side_effect=[-1, -10, -20, -1, -1, "nope", 100],
+        ),
+        caplog.at_level(logging.INFO),
+    ):
+        logger = logging.getLogger("latency_test")
+        logger.addHandler(caplog.handler)
+        res = tester._show_options()
+        logger.removeHandler(caplog.handler)
+
+    # num_times -> default 5; min_wait -> default 0; max_wait -> default 0.1
+    # samples -> default 255; wait_time -> default 3; jitter -> coerced False;
+    # message_length -> default 10
+    assert res == (
+        5,
+        0,
+        0.1,
+        DEFAULT_SAMPLES,
+        DEFAULT_WAIT_TIME,
+        False,
+        DEFAULT_MESSAGE_LENGTH,
+    )
+    assert "Invalid number of times" in caplog.text
+    assert "Invalid min wait time" in caplog.text
+    assert "Invalid max wait time" in caplog.text
+    assert "Invalid number of samples" in caplog.text
+    assert "Invalid wait time" in caplog.text
+    assert "Invalid jitter value" in caplog.text
+    assert "Invalid message length" in caplog.text
+
+
+def test_execute_test_no_serial_logs_and_returns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """execute_test exits early when no serial interface is provided."""
+    tester = LatencyTest(ser=None)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("latency_test")
+        logger.addHandler(caplog.handler)
+        tester.execute_test()
+        logger.removeHandler(caplog.handler)
+    assert "No serial port found. Quitting test." in caplog.text
+
+
+def test_main_test_collects_and_writes_output() -> None:
+    """main_test runs loops, computes bitrate, and writes output via helper."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+
+    # Replace progress bar with a no-op context manager
+    class DummyBar:
+        def __init__(self, *_: Any, **__: Any) -> None: ...
+        def __enter__(self) -> Any:
+            return lambda: None
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    # Use a monotonic counter for perf_counter to avoid zero elapsed time
+    t = {"v": 0.0}
+
+    def fake_perf_counter() -> float:
+        t["v"] += 0.01
+        return t["v"]
+
+    captured: dict[str, Any] = {}
+
+    def fake_write(file_path: Path, output_data: list[dict[str, Any]]) -> None:  # noqa: ARG001
+        captured["data"] = output_data
+
+    with (
+        patch("latency_test.alive_bar", DummyBar),
+        patch("latency_test.time.sleep", lambda _x: None),
+        patch("latency_test.time.perf_counter", side_effect=fake_perf_counter),
+        patch.object(LatencyTest, "_write_output_to_file", side_effect=fake_write),
+    ):
+        tester.main_test(
+            num_times=2,
+            samples=3,
+            min_wait=0.0,
+            max_wait=0.0,
+            wait_time=0.0,
+            jitter=False,
+            length=6,
+        )
+
+    # Validate structure of written data
+    assert "data" in captured
+    out = captured["data"]
+    assert isinstance(out, list)
+    assert len(out) == 2  # noqa: PLR2004
+    for item in out:
+        assert item["samples"] == 3  # noqa: PLR2004
+        assert item["latency_avg"] == 0
+        assert item["latency_min"] == 0
+        assert item["latency_max"] == 0
+        assert item["latency_p95"] == 0
+        assert item["dropped_messages"] == 3  # noqa: PLR2004
+        assert isinstance(item["bitrate"], float)
+        assert item["results"] == []
+
+
+def test_main_test_with_jitter_path() -> None:
+    """main_test with jitter=True exercises the random.uniform sleep path."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+
+    class DummyBar:
+        def __init__(self, *_: Any, **__: Any) -> None: ...
+        def __enter__(self) -> Any:
+            return lambda: None
+
+        def __exit__(self, *_: object) -> None:
+            return None
+
+    t = {"v": 0.0}
+
+    def fake_perf_counter() -> float:
+        t["v"] += 0.01
+        return t["v"]
+
+    with (
+        patch("latency_test.alive_bar", DummyBar),
+        patch("latency_test.time.sleep", lambda _x: None),
+        patch("latency_test.time.perf_counter", side_effect=fake_perf_counter),
+        patch("latency_test.random.uniform", return_value=0.0),
+        patch.object(LatencyTest, "_write_output_to_file"),
+    ):
+        tester.main_test(
+            num_times=2,
+            samples=2,
+            min_wait=0.0,
+            max_wait=0.1,
+            wait_time=0.0,
+            jitter=True,
+            length=6,
+        )

--- a/tests/test_serial_interface.py
+++ b/tests/test_serial_interface.py
@@ -1,0 +1,247 @@
+"""Tests for src/serial_interface.py."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import Mock, patch
+
+import serial
+from cobs import cobs
+
+from serial_interface import SerialCommand, SerialInterface
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def make_interface() -> SerialInterface:
+    """Make a SerialInterface instance for testing."""
+    return SerialInterface(port="COM1", baudrate=115200, timeout=0.1)
+
+
+def test_open_success() -> None:
+    """Test successful open of serial port."""
+    si = make_interface()
+
+    ser_mock = Mock()
+    ser_mock.is_open = True
+    with patch("serial_interface.serial.Serial", return_value=ser_mock):
+        ok = si.open()
+    assert ok is True
+    assert si.ser is ser_mock
+    assert ser_mock.write_timeout == 0
+    ser_mock.reset_input_buffer.assert_called_once()
+    ser_mock.reset_output_buffer.assert_called_once()
+    assert ser_mock.rts is True
+
+
+def test_open_failure() -> None:
+    """Test failed open of serial port."""
+    si = make_interface()
+    with patch("serial_interface.serial.Serial", side_effect=serial.SerialException):
+        ok = si.open()
+    assert ok is False
+
+
+def test_is_open_states() -> None:
+    """Test is_open property reflects serial port state."""
+    si = make_interface()
+    assert si.is_open() is False
+    ser_mock = Mock()
+    ser_mock.is_open = True
+    si.ser = ser_mock
+    assert si.is_open() is True
+    ser_mock.is_open = False
+    assert si.is_open() is False
+
+
+def test_send_command_invalid_hex_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Test sending invalid hex command logs error."""
+    si = make_interface()
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        si.send_command("ABC")  # odd-length
+        logger.removeHandler(caplog.handler)
+    assert "Invalid hex data" in caplog.text
+
+
+def test_send_command_valid_calls_write() -> None:
+    """Test sending valid hex command calls write with correct bytes."""
+    si = make_interface()
+    with patch.object(SerialInterface, "write") as mock_write:
+        si.send_command("0014")  # 0x00, 0x14
+    mock_write.assert_called_once_with(bytes.fromhex("0014"))
+
+
+def test_write_without_ser_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Test write when serial port is not open logs info."""
+    si = make_interface()
+    si.ser = None
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        si.write(b"\x00\x14")
+        logger.removeHandler(caplog.handler)
+    assert "Serial port not open" in caplog.text
+
+
+def test_write_updates_stats_and_calls_serial() -> None:
+    """Test write updates statistics and calls serial write."""
+    si = make_interface()
+    ser_mock = Mock()
+    # bytes_written equals actual message length passed
+    ser_mock.write.side_effect = lambda m: len(m)
+    si.ser = ser_mock
+
+    # command is data[1] & 0x1F -> 0x14 -> 20
+    payload = b"\x00" + bytes([SerialCommand.ECHO_COMMAND.value]) + b"abc"
+    si.write(payload)
+
+    # bytes_sent updated and command count incremented
+    assert si.statistics.bytes_sent > 0
+    assert si.statistics.commands_sent[SerialCommand.ECHO_COMMAND.value] == 1
+    # Published encoded message was sent to serial
+    ser_mock.write.assert_called_once()
+
+
+def test_write_with_stop_event_set_does_nothing() -> None:
+    """Test write does nothing if stop event is set."""
+    si = make_interface()
+    ser_mock = Mock()
+    si.ser = ser_mock
+    si.stop_event.set()
+    si.write(b"\x00\x14")
+    ser_mock.write.assert_not_called()
+
+
+def test_write_index_error_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Test write with too-short message logs error."""
+    si = make_interface()
+    ser_mock = Mock()
+    ser_mock.write.side_effect = lambda m: len(m)
+    si.ser = ser_mock
+
+    with caplog.at_level(logging.ERROR):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        si.write(b"\x00")  # too short to index data[1]
+        logger.removeHandler(caplog.handler)
+    assert "Error processing message to send" in caplog.text
+
+
+def test_process_complete_message_success_calls_handler() -> None:
+    """Test processing a complete message successfully calls the handler."""
+    si = make_interface()
+    called: dict[str, Any] = {}
+
+    def handler(command: int, decoded: bytes, raw: bytes) -> None:
+        called["cmd"] = command
+        called["decoded"] = decoded
+        called["raw"] = raw
+
+    si.set_message_handler(handler)
+    decoded = b"\xaa" + bytes([SerialCommand.KEY_COMMAND.value]) + b"XYZ"
+    raw = cobs.encode(decoded)
+    si._process_complete_message(raw)
+
+    assert called["cmd"] == SerialCommand.KEY_COMMAND.value
+    assert called["decoded"] == decoded
+    assert called["raw"] == raw
+    assert si.statistics.commands_received[SerialCommand.KEY_COMMAND.value] == 1
+
+
+def test_process_complete_message_decode_error_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test processing a message that fails COBS decoding logs error."""
+    si = make_interface()
+    with (
+        patch("serial_interface.cobs.decode", side_effect=cobs.DecodeError),
+        caplog.at_level(logging.ERROR),
+    ):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        si._process_complete_message(b"\x01\x02")
+        logger.removeHandler(caplog.handler)
+    assert "Error processing message" in caplog.text
+
+
+def test_handle_received_data_queue_and_rts_toggle() -> None:
+    """Test handling received data queues messages and toggles RTS based on buffer."""
+    si = make_interface()
+    # Shrink watermarks for the test
+    si.BUFFER_HIGH_WATER = 3  # pyright: ignore[reportAttributeAccessIssue]
+    si.BUFFER_LOW_WATER = 1  # pyright: ignore[reportAttributeAccessIssue]
+    ser_mock = Mock()
+    ser_mock.rts = True
+    si.ser = ser_mock
+
+    # Pre-fill buffer beyond high watermark so the first check disables RTS
+    si.buffer = bytearray(b"XXXX")
+    si._handle_received_data(
+        b"\x00", max_message_size=100
+    )  # Clear buffer, queue 'XXXX'
+    assert ser_mock.rts is False
+    assert si.buffer == bytearray()
+
+    # Next call sees buffer below low watermark, enabling RTS
+    si._handle_received_data(b"", max_message_size=100)
+    assert ser_mock.rts is True
+
+    # Send a valid message (COBS encoded + delimiter) and ensure it lands in queue
+    msg = cobs.encode(b"hi")
+    si._handle_received_data(msg + b"\x00", max_message_size=100)
+    # First queued item was the prefill ('XXXX'), discard it
+    first = si.message_queue.get(timeout=0.5)
+    assert first == b"XXXX"
+    out = si.message_queue.get(timeout=0.5)
+    assert out == msg
+    assert si.statistics.bytes_received >= len(msg) + 1
+
+
+def test_handle_received_data_max_size_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling received data that exceeds max size logs warning."""
+    si = make_interface()
+    si.ser = Mock()
+    with caplog.at_level(logging.WARNING):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        # Exceed max_message_size to trigger warning and buffer clear
+        si._handle_received_data(b"ABCDE", max_message_size=3)
+        logger.removeHandler(caplog.handler)
+    assert "Message exceeded maximum size" in caplog.text
+    # After clearing on overflow, the remaining byte ('E') is appended
+    assert si.buffer == bytearray(b"E")
+
+
+def test_read_data_disconnected_path(caplog: pytest.LogCaptureFixture) -> None:
+    """Test read data when serial port is disconnected."""
+    si = make_interface()
+    si.ser = None
+    with caplog.at_level(logging.ERROR):
+        logger = logging.getLogger("serial_interface")
+        logger.addHandler(caplog.handler)
+        si._read_data()
+        logger.removeHandler(caplog.handler)
+    assert "Serial port disconnected" in caplog.text
+    assert si.stop_event.is_set()
+
+
+def test_close_joins_threads_and_closes_ser() -> None:
+    """Test close method joins threads and closes serial port."""
+    si = make_interface()
+    # Replace threads with mocks that have join
+    si.read_thread = Mock()
+    si.processing_thread = Mock()
+    ser_mock = Mock()
+    ser_mock.is_open = True
+    si.ser = ser_mock
+
+    si.close()
+    si.read_thread.join.assert_called_once()
+    si.processing_thread.join.assert_called_once()
+    ser_mock.close.assert_called_once()

--- a/tests/test_status_mode.py
+++ b/tests/test_status_mode.py
@@ -1,0 +1,239 @@
+"""Tests for src/status_mode.py."""
+
+from __future__ import annotations
+
+import logging
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import Mock, patch
+
+from serial_interface import SerialCommand
+from status_mode import (
+    STATISTICS_HEADER_BYTES,
+    StatusMode,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class DummyStats:
+    """Dummy statistics object for testing."""
+
+    def __init__(self) -> None:
+        """Initialize dummy statistics."""
+        self.bytes_received = 0
+        self.bytes_sent = 0
+        self.commands_sent: dict[int, int] = {}
+        self.commands_received: dict[int, int] = {}
+
+
+def make_status_mode() -> StatusMode:
+    """Make a StatusMode instance for testing."""
+    ser = SimpleNamespace(write=Mock(), statistics=DummyStats())
+    return StatusMode(ser=ser)  # type: ignore[arg-type]
+
+
+def test_handle_message_updates_statistics(caplog: pytest.LogCaptureFixture) -> None:
+    """Test handling a statistics status message updates the correct item."""
+    sm = make_status_mode()
+    idx = sm.StatisticsCodes.QUEUE_SEND_ERROR
+    value = 123456
+    payload = bytes([0x00, 0x00, 0x00, idx]) + value.to_bytes(4, "big")
+
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("status_mode")
+        logger.addHandler(caplog.handler)
+        sm.handle_message(SerialCommand.STATISTICS_STATUS_COMMAND.value, payload)
+        logger.removeHandler(caplog.handler)
+
+    item = sm.error_items[idx]
+    assert item.value == value
+    assert item.last_updated != 0
+    assert f"{item.message} value updated to {value}" in caplog.text
+
+
+def test_handle_message_updates_task_fields(caplog: pytest.LogCaptureFixture) -> None:
+    """Test handling a task status message updates the correct task fields."""
+    sm = make_status_mode()
+    idx = sm.TaskIndex.IDLE_TASK_INDEX
+    abs_time = 3_210_000
+    perc_time = 42
+    hwm = 777
+    # command byte array indices expected: 3=index, 4-7 abs, 8-11 perc, 12-15 hwm
+    payload = (
+        bytes([0x00, 0x00, 0x00, idx])
+        + abs_time.to_bytes(4, "big")
+        + perc_time.to_bytes(4, "big")
+        + hwm.to_bytes(4, "big")
+    )
+
+    with caplog.at_level(logging.INFO):
+        logger = logging.getLogger("status_mode")
+        logger.addHandler(caplog.handler)
+        sm.handle_message(SerialCommand.TASK_STATUS_COMMAND.value, payload)
+        logger.removeHandler(caplog.handler)
+
+    t = sm.task_items[idx]
+    assert t.absoulute_time == abs_time
+    assert t.percent_time == perc_time
+    assert t.high_watermark == hwm
+    assert t.last_updated != 0
+    assert f"[{t.name}] updated" in caplog.text
+
+
+def test_handle_message_index_error_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Test handling a message with bad index logs error."""
+    sm = make_status_mode()
+    with caplog.at_level(logging.ERROR):
+        logger = logging.getLogger("status_mode")
+        logger.addHandler(caplog.handler)
+        sm.handle_message(SerialCommand.TASK_STATUS_COMMAND.value, b"\x01\x02")
+        logger.removeHandler(caplog.handler)
+    assert "Error parsing status command" in caplog.text
+
+
+def test_status_update_builds_payload_and_writes() -> None:
+    """Test status update builds correct payload and calls write."""
+    sm = make_status_mode()
+    sm._status_update(STATISTICS_HEADER_BYTES, 5)
+    # payload should be: header + 0x01 + index
+    (payload,), _ = sm.ser.write.call_args  # pyright: ignore[reportAttributeAccessIssue]
+    assert payload[:2] == STATISTICS_HEADER_BYTES
+    assert payload[2] == 0x01
+    assert payload[3] == 5  # noqa: PLR2004
+
+
+def test_update_statistics_status_requests_all(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test updating statistics status requests all statistics."""
+    sm = make_status_mode()
+    with (
+        patch.object(StatusMode, "_status_update") as upd,
+        patch("status_mode.time.sleep", lambda _x: None),
+        caplog.at_level(logging.INFO),
+    ):
+        logger = logging.getLogger("status_mode")
+        logger.addHandler(caplog.handler)
+        sm._update_statistics_status()
+        logger.removeHandler(caplog.handler)
+
+    assert upd.call_count == len(sm.error_items)
+    assert "Status request complete" in caplog.text
+
+
+def test_update_task_status_requests_all(caplog: pytest.LogCaptureFixture) -> None:
+    """Test updating task status requests all tasks."""
+    sm = make_status_mode()
+    with (
+        patch.object(StatusMode, "_status_update") as upd,
+        patch("status_mode.time.sleep", lambda _x: None),
+        caplog.at_level(logging.INFO),
+    ):
+        logger = logging.getLogger("status_mode")
+        logger.addHandler(caplog.handler)
+        sm._update_task_status()
+        logger.removeHandler(caplog.handler)
+
+    assert upd.call_count == len(sm.task_items)
+    assert "Status request complete" in caplog.text
+
+
+def test_display_statistics_status_outputs_tables(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test displaying statistics status outputs formatted tables."""
+    sm = make_status_mode()
+    # Prime some values
+    first_idx = next(iter(sm.error_items))
+    sm.error_items[first_idx].value = 9001
+    sm.error_items[first_idx].last_updated = time.time()
+    sm.ser.statistics.bytes_sent = 123
+    sm.ser.statistics.bytes_received = 456
+    sm.ser.statistics.commands_sent = {SerialCommand.ECHO_COMMAND.value: 2}
+    sm.ser.statistics.commands_received = {SerialCommand.KEY_COMMAND.value: 3}
+
+    sm._display_statistics_status()
+    out = capsys.readouterr().out
+
+    assert "Statistics Status:" in out
+    assert "Statistics Counters:" in out
+    # Ensure counter name and human-formatted value present
+    assert sm.error_items[first_idx].message in out
+    assert "9,001" in out
+    # Commands stats and totals
+    assert "Commands Sent Stastitics:" in out
+    assert "ECHO_COMMAND" in out
+    assert "2" in out
+    assert "Commands Received Stastitics:" in out
+    assert "KEY_COMMAND" in out
+    assert "3" in out
+    assert "Total bytes sent: 123" in out
+    assert "Total bytes received: 456" in out
+
+
+def test_format_time_from_microseconds() -> None:
+    """Test formatting time from microseconds to mm:ss:ms string."""
+    sm = make_status_mode()
+    assert sm.format_time_from_microseconds(0) == "00:00:000"
+    # 1 minute, 2 seconds, 345 ms -> total microseconds = 62,345,000
+    assert sm.format_time_from_microseconds(62_345_000) == "01:02:345"
+
+
+def test_display_task_status_outputs_table(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test displaying task status outputs formatted table."""
+    sm = make_status_mode()
+    # Fill some task values
+    sm.task_items[sm.TaskIndex.CDC_TASK_INDEX].absoulute_time = 10_000
+    sm.task_items[sm.TaskIndex.UART_EVENT_TASK_INDEX].absoulute_time = 20_000
+    sm.task_items[sm.TaskIndex.IDLE_TASK_INDEX].absoulute_time = 30_000
+    sm.task_items[sm.TaskIndex.ENCODER_READ_TASK_INDEX].absoulute_time = 40_000
+    sm.task_items[sm.TaskIndex.ADC_READ_TASK_INDEX].absoulute_time = 50_000
+    sm.task_items[sm.TaskIndex.KEYPAD_TASK_INDEX].absoulute_time = 60_000
+    sm.task_items[sm.TaskIndex.PROCESS_OUTBOUND_TASK_INDEX].absoulute_time = 70_000
+    sm.task_items[sm.TaskIndex.DECODE_RECEPTION_TASK_INDEX].absoulute_time = 80_000
+    sm.task_items[sm.TaskIndex.CDC_TASK_INDEX].percent_time = 11
+    sm.task_items[sm.TaskIndex.CDC_TASK_INDEX].high_watermark = 99
+
+    sm._display_task_status()
+    out = capsys.readouterr().out
+
+    # Table headings
+    assert "Task Status:" in out
+    assert "Absolute Time (mm:ss:ms)" in out
+    # A formatted task row (CDC Task)
+    assert "CDC Task" in out
+    assert "% Time" in out
+    assert "99" in out
+    # Totals
+    assert "Core 0 total time:" in out
+    assert "Core 1 total time:" in out
+
+
+def test_handle_user_choice_dispatch() -> None:
+    """Test handling user menu choices dispatches to correct methods."""
+    sm = make_status_mode()
+    with (
+        patch.object(sm, "_update_statistics_status") as upd_stats,
+        patch.object(sm, "_update_task_status") as upd_tasks,
+    ):
+        assert sm._handle_user_choice("1") is True
+        upd_stats.assert_called_once()
+        assert sm._handle_user_choice("2") is True
+        upd_tasks.assert_called_once()
+        assert sm._handle_user_choice("3") is True
+        assert sm._handle_user_choice("4") is False
+        assert sm._handle_user_choice("x") is True
+
+
+def test_execute_test_exits_on_choice_four() -> None:
+    """Test executing test exits when user selects choice 4."""
+    sm = make_status_mode()
+    with (
+        patch.object(sm, "_display_statistics_status"),
+        patch.object(sm, "_display_task_status"),
+        patch("builtins.input", return_value="4"),
+    ):
+        sm.execute_test()

--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import numpy as np
 import pytest
@@ -84,13 +84,94 @@ def test_plot_boxplot(visualize_results: VisualizeResults) -> None:
 
 
 def test_plot_histogram(visualize_results: VisualizeResults) -> None:
-    """Test for the plot_histogram method."""
-    test_data = [np.array([0.01, 0.02, 0.03])]
-    labels = ["Test 1"]
-    stats_data = [{"p95": 0.03, "avg": 0.02, "min": 0.01, "max": 0.03}]
-    with patch("matplotlib.pyplot.show") as mock_show:
+    """Test for the plot_histogram method with detailed assertions."""
+    test_data = [np.array([0.01, 0.02, 0.03]), np.array([0.04, 0.05, 0.06])]
+    labels = ["T1", "T2"]
+    stats_data = [
+        {"p95": 0.03, "avg": 0.02, "min": 0.01, "max": 0.03},
+        {"p95": 0.06, "avg": 0.05, "min": 0.04, "max": 0.06},
+    ]
+
+    ax1 = Mock()
+    ax2 = Mock()
+    ax1.get_ylim.return_value = (0, 10)
+    ax2.get_ylim.return_value = (0, 10)
+    fig = Mock()
+
+    with (
+        patch(
+            "visualize_results.plt.subplots", return_value=(fig, [ax1, ax2])
+        ) as subplots,
+        patch("visualize_results.plt.subplots_adjust") as subplots_adjust,
+        patch("visualize_results.plt.tight_layout"),
+        patch("visualize_results.plt.show") as mock_show,
+        patch("visualize_results.cm.get_cmap", return_value=lambda v: ["red", "blue"]),  # noqa: ARG005
+    ):
         visualize_results.plot_histogram(test_data, labels, stats_data)
-        mock_show.assert_called_once()
+
+    # First axis assertions
+    ax1.hist.assert_called_once()
+    _, kwargs1 = ax1.hist.call_args
+    assert kwargs1["bins"] == 50  # noqa: PLR2004
+    assert kwargs1["alpha"] == pytest.approx(0.75)
+    assert kwargs1["label"] == "T1"
+    assert kwargs1["color"] == "red"
+    assert kwargs1["histtype"] == "stepfilled"
+
+    # p95 vertical line and text label
+    ax1.axvline.assert_called_once_with(0.03, color="red", linestyle="--", alpha=1.0)
+    ax1.text.assert_any_call(
+        0.03,
+        10,
+        "P95: 0.0ms",
+        rotation=90,
+        va="top",
+        ha="right",
+        bbox=visualize_results.bbox_props,
+    )
+    ax1.set_title.assert_called()
+    ax1.set_xlabel.assert_called_with("Latency (ms)")
+    ax1.grid.assert_called_with(axis="y", linestyle="--", alpha=0.7)
+
+    # Second axis basic checks
+    assert ax2.hist.call_count == 1
+    _, kwargs2 = ax2.hist.call_args
+    assert kwargs2["label"] == "T2"
+    assert kwargs2["color"] == "blue"
+    # Layout calls
+    subplots.assert_called_once()
+    assert subplots.call_args.kwargs.get("sharey") is True
+    subplots_adjust.assert_called_once_with(wspace=0)
+    mock_show.assert_called_once()
+
+
+def test_plot_histogram_layout_and_color_sampling(
+    visualize_results: VisualizeResults,
+) -> None:
+    """Verify layout and color sampling arguments are correct."""
+    test_data = [np.array([0.01, 0.02, 0.03])]
+    labels = ["Only"]
+    stats_data = [{"p95": 0.03, "avg": 0.02, "min": 0.01, "max": 0.03}]
+
+    ax = Mock()
+    ax.get_ylim.return_value = (0, 1)
+    fig = Mock()
+
+    linspace_mock = Mock(return_value=[0.0])
+
+    with (
+        patch("visualize_results.plt.subplots", return_value=(fig, ax)),
+        patch("visualize_results.plt.subplots_adjust") as subplots_adjust,
+        patch("visualize_results.plt.show"),
+        patch("visualize_results.cm.get_cmap", return_value=lambda v: ["green"]),  # noqa: ARG005
+        patch("visualize_results.np.linspace", linspace_mock),
+    ):
+        visualize_results.plot_histogram(test_data, labels, stats_data)
+
+    # subplots_adjust should enforce zero spacing
+    subplots_adjust.assert_called_once_with(wspace=0)
+    # color sampling spans 0..1 with count == len(test_data)
+    linspace_mock.assert_called_once_with(0, 1, len(test_data))
 
 
 def test_get_test_files(visualize_results: VisualizeResults) -> None:

--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -7,7 +7,7 @@ from unittest.mock import mock_open, patch
 import numpy as np
 import pytest
 
-from src.visualize_results import VisualizeResults
+from visualize_results import VisualizeResults
 
 
 @pytest.fixture
@@ -18,7 +18,7 @@ def visualize_results() -> VisualizeResults:
 
 def test_select_test_file_no_files(visualize_results: VisualizeResults) -> None:
     """Test for the select_test_file method when no files are found."""
-    with patch("src.visualize_results.Path.glob", return_value=[]):
+    with patch("visualize_results.Path.glob", return_value=[]):
         result = visualize_results.select_test_file()
         assert result is None
 
@@ -27,7 +27,7 @@ def test_select_test_file_with_files(visualize_results: VisualizeResults) -> Non
     """Test for the select_test_file method when files are found."""
     mock_files = [Path(f"test_{i}.json") for i in range(15)]
     with (
-        patch("src.visualize_results.Path.glob", return_value=mock_files),
+        patch("visualize_results.Path.glob", return_value=mock_files),
         patch("builtins.input", side_effect=["1", "q"]),
     ):
         result = visualize_results.select_test_file()
@@ -86,7 +86,7 @@ def test_plot_boxplot(visualize_results: VisualizeResults) -> None:
 def test_get_test_files(visualize_results: VisualizeResults) -> None:
     """Test for the _get_test_files method."""
     mock_files = [Path(f"test_{i}.json") for i in range(5)]
-    with patch("src.visualize_results.Path.glob", return_value=mock_files):
+    with patch("visualize_results.Path.glob", return_value=mock_files):
         files = visualize_results._get_test_files()
         assert files == mock_files
 

--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -83,6 +83,16 @@ def test_plot_boxplot(visualize_results: VisualizeResults) -> None:
         mock_show.assert_called_once()
 
 
+def test_plot_histogram(visualize_results: VisualizeResults) -> None:
+    """Test for the plot_histogram method."""
+    test_data = [np.array([0.01, 0.02, 0.03])]
+    labels = ["Test 1"]
+    stats_data = [{"p95": 0.03, "avg": 0.02, "min": 0.01, "max": 0.03}]
+    with patch("matplotlib.pyplot.show") as mock_show:
+        visualize_results.plot_histogram(test_data, labels, stats_data)
+        mock_show.assert_called_once()
+
+
 def test_get_test_files(visualize_results: VisualizeResults) -> None:
     """Test for the _get_test_files method."""
     mock_files = [Path(f"test_{i}.json") for i in range(5)]


### PR DESCRIPTION
## Summary
- Stub dependent modules and constants so mutation tests can import the application without errors
- Configure `mutmut` to limit mutation scope to key modules for faster execution

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `mutmut run` *(stopped after ~460/862 mutants: 0.80 mutants/sec)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4a2cc520832fb78e2cae404a7281