### PR TITLE
Isolate log I/O from producer threads via async queue dispatch

### DIFF
--- a/src/logger_config.py
+++ b/src/logger_config.py
@@ -1,9 +1,21 @@
 """Module to setup logging configuration from file."""
 
+from __future__ import annotations
+
+import atexit
 import logging
 import logging.config
+import logging.handlers
 import os
+import queue
 from pathlib import Path
+
+
+class _Dispatch:
+    """Module-local state for the async logging dispatcher."""
+
+    listener: logging.handlers.QueueListener | None = None
+    atexit_registered: bool = False
 
 
 def setup_logging(
@@ -11,7 +23,13 @@ def setup_logging(
     default_level: int = logging.INFO,
     env_key: str = "LOG_CFG",
 ) -> None:
-    """Open setup logging configuration from file."""
+    """
+    Configure logging with a non-blocking, queue-based dispatcher.
+
+    Loggers receive a single `QueueHandler` that enqueues records and returns
+    immediately; a background `QueueListener` thread owns the real I/O
+    handlers so stdout/file writes never block producer threads.
+    """
     path: Path = Path(__file__).parent.parent / default_path
     value = os.getenv(env_key, None)
     if value:
@@ -21,3 +39,66 @@ def setup_logging(
         logging.config.fileConfig(path.resolve(), disable_existing_loggers=False)
     else:
         logging.basicConfig(level=default_level)
+
+    _install_queue_dispatch()
+
+
+def _collect_configured_loggers() -> list[logging.Logger]:
+    """Return the root logger plus every named logger currently registered."""
+    loggers: list[logging.Logger] = [logging.getLogger()]
+    for name in list(logging.root.manager.loggerDict):
+        candidate = logging.getLogger(name)
+        if isinstance(candidate, logging.Logger):
+            loggers.append(candidate)
+    return loggers
+
+
+def _collect_real_handlers(loggers: list[logging.Logger]) -> list[logging.Handler]:
+    """Return unique, non-queue handlers attached to the given loggers."""
+    seen: set[int] = set()
+    real_handlers: list[logging.Handler] = []
+    for logger in loggers:
+        for handler in logger.handlers:
+            if isinstance(handler, logging.handlers.QueueHandler):
+                continue
+            if id(handler) not in seen:
+                seen.add(id(handler))
+                real_handlers.append(handler)
+    return real_handlers
+
+
+def _install_queue_dispatch() -> None:
+    """Route every configured logger through a queue served by one thread."""
+    loggers = _collect_configured_loggers()
+    real_handlers = _collect_real_handlers(loggers)
+
+    if not real_handlers:
+        return
+
+    log_queue: queue.Queue[logging.LogRecord] = queue.Queue(-1)
+    queue_handler = logging.handlers.QueueHandler(log_queue)
+
+    for logger in loggers:
+        if logger.handlers:
+            logger.handlers = [queue_handler]
+
+    if _Dispatch.listener is not None:
+        _Dispatch.listener.stop()
+
+    _Dispatch.listener = logging.handlers.QueueListener(
+        log_queue,
+        *real_handlers,
+        respect_handler_level=True,
+    )
+    _Dispatch.listener.start()
+
+    if not _Dispatch.atexit_registered:
+        atexit.register(_stop_listener)
+        _Dispatch.atexit_registered = True
+
+
+def _stop_listener() -> None:
+    """Drain the queue and stop the background dispatcher thread."""
+    if _Dispatch.listener is not None:
+        _Dispatch.listener.stop()
+        _Dispatch.listener = None

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import logging
+import logging.handlers
 import os
+import time
 from pathlib import Path
 from unittest.mock import patch
 
-from logger_config import setup_logging
+import pytest
+
+from logger_config import _Dispatch, _install_queue_dispatch, setup_logging
 
 
 class TestSetupLogging:
@@ -92,3 +96,93 @@ class TestSetupLogging:
             setup_logging()
         _, kwargs = mock_file_config.call_args
         assert kwargs["disable_existing_loggers"] is False
+
+
+class TestQueueDispatch:
+    """Exercise the non-blocking queue-based logging dispatcher."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_logging(self) -> None:
+        saved_listener = _Dispatch.listener
+        if saved_listener is not None:
+            saved_listener.stop()
+        _Dispatch.listener = None
+
+        root = logging.getLogger()
+        saved_root_handlers = list(root.handlers)
+        saved_root_level = root.level
+        saved_children: dict[str, tuple[list[logging.Handler], int]] = {}
+        for name in list(logging.root.manager.loggerDict):
+            existing = logging.getLogger(name)
+            if isinstance(existing, logging.Logger):
+                saved_children[name] = (list(existing.handlers), existing.level)
+                existing.handlers = []
+
+        root.handlers = []
+        root.setLevel(logging.WARNING)
+        yield
+
+        if _Dispatch.listener is not None:
+            _Dispatch.listener.stop()
+            _Dispatch.listener = None
+        root.handlers = saved_root_handlers
+        root.setLevel(saved_root_level)
+        for name, (handlers, level) in saved_children.items():
+            restored = logging.getLogger(name)
+            restored.handlers = handlers
+            restored.setLevel(level)
+
+    def test_install_replaces_real_handlers_with_queue_handler(self) -> None:
+        sink = logging.Handler()
+        root = logging.getLogger()
+        root.addHandler(sink)
+
+        _install_queue_dispatch()
+
+        assert len(root.handlers) == 1
+        assert isinstance(root.handlers[0], logging.handlers.QueueHandler)
+        assert _Dispatch.listener is not None
+
+    def test_listener_owns_original_handlers(self) -> None:
+        sink = logging.Handler()
+        logging.getLogger().addHandler(sink)
+
+        _install_queue_dispatch()
+
+        assert _Dispatch.listener is not None
+        assert sink in _Dispatch.listener.handlers
+
+    def test_records_are_delivered_through_queue(self) -> None:
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        sink = _Capture(level=logging.DEBUG)
+        root = logging.getLogger()
+        root.setLevel(logging.DEBUG)
+        root.addHandler(sink)
+
+        _install_queue_dispatch()
+        logging.getLogger("queue_dispatch_test").info("hello")
+
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and not captured:
+            time.sleep(0.01)
+
+        assert any(rec.getMessage() == "hello" for rec in captured)
+
+    def test_install_is_idempotent(self) -> None:
+        sink = logging.Handler()
+        logging.getLogger().addHandler(sink)
+
+        _install_queue_dispatch()
+        first_listener = _Dispatch.listener
+        _install_queue_dispatch()
+        second_listener = _Dispatch.listener
+
+        assert first_listener is not None
+        assert second_listener is not None
+        # The second call is a no-op: no real handlers left to collect.
+        assert first_listener is second_listener

--- a/uv.lock
+++ b/uv.lock
@@ -838,27 +838,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.8"
+version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
-    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
 ]
 
 [[package]]
@@ -939,12 +939,12 @@ dev = [
 requires-dist = [
     { name = "alive-progress", specifier = "==3.3.0" },
     { name = "cobs", specifier = "==1.2.2" },
-    { name = "matplotlib", specifier = ">=3.8.2" },
+    { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.2.1" },
     { name = "pre-commit", specifier = "==4.5.1" },
     { name = "pyserial", specifier = "==3.5" },
     { name = "rich", specifier = ">=13.9.0" },
-    { name = "ruff", specifier = "==0.15.8" },
+    { name = "ruff", specifier = "==0.15.9" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Console/file handlers in logging_config.ini are synchronous: at high
baud rates, per-message logger.info() calls in SerialInterface.write
and BaseTest.handle_message block the processing thread on stdout
backpressure, inflating measured latency into a ~0-200 ms uniform
distribution even though no messages are dropped.

setup_logging now installs a single QueueHandler on every configured
logger and moves the real stdout/file handlers into a background
QueueListener thread. Producers enqueue LogRecords in microseconds and
return; disk/terminal I/O can no longer stall the measurement path.