### PR TITLE
feat: remove encoder_read_task and merge into keypad task

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,24 +53,24 @@ TIMEOUT   = 0.1                   # Read timeout in seconds
 
 Common port names:
 
-| OS      | Example                   |
-| ------- | ------------------------- |
-| macOS   | `/dev/cu.usbmodem101`     |
-| Linux   | `/dev/ttyACM0`            |
-| Windows | `COM3`                    |
+| OS      | Example               |
+| ------- | --------------------- |
+| macOS   | `/dev/cu.usbmodem101` |
+| Linux   | `/dev/ttyACM0`        |
+| Windows | `COM3`                |
 
 ## ✨ Features
 
-| Module               | Description                                                       |
-| -------------------- | ----------------------------------------------------------------- |
-| Latency test         | High-precision roundtrip latency with P95 statistics              |
-| Baud rate sweep      | Automated sweep across multiple baud rates                        |
-| Stress test          | Five configurable scenarios (echo burst, mixed commands, etc.)    |
-| Command mode         | Interactive hex command sending with real-time response display   |
-| Status mode          | Live statistics and FreeRTOS task performance monitoring          |
-| Regression test      | Automated echo-command validation                                 |
-| Visualize results    | Boxplot, histogram, controller health, and error counter charts   |
-| Keypad & ADC monitor | Real-time sparkline display of ADC channels and keypad events     |
+| Module               | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| Latency test         | High-precision roundtrip latency with P95 statistics            |
+| Baud rate sweep      | Automated sweep across multiple baud rates                      |
+| Stress test          | Five configurable scenarios (echo burst, mixed commands, etc.)  |
+| Command mode         | Interactive hex command sending with real-time response display |
+| Status mode          | Live statistics and FreeRTOS task performance monitoring        |
+| Regression test      | Automated echo-command validation                               |
+| Visualize results    | Boxplot, histogram, controller health, and error counter charts |
+| Keypad & ADC monitor | Real-time sparkline display of ADC channels and keypad events   |
 
 **Protocol stack:** COBS framing · XOR checksum · hardware RTS/CTS flow control · multi-threaded read/write
 
@@ -107,15 +107,15 @@ Measures roundtrip echo latency across configurable iterations and sample counts
 
 **Interactive prompts (7 steps):**
 
-| # | Parameter | Default |
-|---|-----------|---------|
-| 1 | Number of test iterations | 5 |
-| 2 | Message length (6–10 bytes) | 10 |
-| 3 | Min wait between samples (ms) | 0 |
-| 4 | Max wait between samples (ms) | 100 |
-| 5 | Samples per iteration | 255 |
-| 6 | Wait between iterations (s) | 3 |
-| 7 | Enable jitter | false |
+| #   | Parameter                     | Default |
+| --- | ----------------------------- | ------- |
+| 1   | Number of test iterations     | 5       |
+| 2   | Message length (6–10 bytes)   | 10      |
+| 3   | Min wait between samples (ms) | 0       |
+| 4   | Max wait between samples (ms) | 100     |
+| 5   | Samples per iteration         | 255     |
+| 6   | Wait between iterations (s)   | 3       |
+| 7   | Enable jitter                 | false   |
 
 Results are saved to `test_results/{timestamp}_output.json` with latency samples, avg/min/max/P95, dropped message count, and bitrate.
 
@@ -129,12 +129,12 @@ Sweeps through a list of baud rates and measures echo latency at each rate.
 
 **Interactive prompts (4 steps):**
 
-| # | Parameter | Default |
-|---|-----------|---------|
-| 1 | Use default baud rates? | True |
-| 2 | Samples per baud rate | 255 |
-| 3 | Wait after each burst (s) | 3 |
-| 4 | Message length (6–10 bytes) | 10 |
+| #   | Parameter                   | Default |
+| --- | --------------------------- | ------- |
+| 1   | Use default baud rates?     | True    |
+| 2   | Samples per baud rate       | 255     |
+| 3   | Wait after each burst (s)   | 3       |
+| 4   | Message length (6–10 bytes) | 10      |
 
 Default baud rates: `[9600, 57600, 115200, 230400, 460800, 921600]`
 
@@ -142,13 +142,13 @@ Default baud rates: `[9600, 57600, 115200, 230400, 460800, 921600]`
 
 Runs five automated scenarios in sequence (or individually) with pass/fail verdicts:
 
-| Scenario | Profile | Messages | Key threshold |
-|---|---|---|---|
-| `echo_burst` | Echo only | 500 | Drop ratio < 0.1 % · P95 < 50 ms |
-| `mixed_command_burst` | Echo + status | 400 | Drop ratio < 0.5 % · P95 < 100 ms |
-| `status_poll_storm` | Status only | 200 | Queue send errors = 0 |
-| `baud_flip` | Echo at each baud | 5 per rate | 0 % drop · recovery < 3 s |
-| `noise_and_recovery` | Noise injection | 10 | Full recovery · P95 < 2 000 ms |
+| Scenario              | Profile           | Messages   | Key threshold                     |
+| --------------------- | ----------------- | ---------- | --------------------------------- |
+| `echo_burst`          | Echo only         | 500        | Drop ratio < 0.1 % · P95 < 50 ms  |
+| `mixed_command_burst` | Echo + status     | 400        | Drop ratio < 0.5 % · P95 < 100 ms |
+| `status_poll_storm`   | Status only       | 200        | Queue send errors = 0             |
+| `baud_flip`           | Echo at each baud | 5 per rate | 0 % drop · recovery < 3 s         |
+| `noise_and_recovery`  | Noise injection   | 10         | Full recovery · P95 < 2 000 ms    |
 
 A JSON report is written to `test_results/{run_id}_stress.json` after each run. A Rich summary table is printed to the terminal.
 
@@ -167,16 +167,16 @@ Polls and displays FreeRTOS statistics and task performance in Rich tables.
 
 **Available actions:**
 
-| Key | Action |
-|-----|--------|
-| 1 | Request statistics status update |
-| 2 | Request task status update |
-| 3 | Refresh display |
-| 4 | Exit |
+| Key | Action                           |
+| --- | -------------------------------- |
+| 1   | Request statistics status update |
+| 2   | Request task status update       |
+| 3   | Refresh display                  |
+| 4   | Exit                             |
 
 **Statistics monitored:** queue send/receive errors, checksum errors, buffer overflows, unknown commands, bytes sent/received.
 
-**Tasks monitored:** `cdc_task`, `cdc_write_task`, `uart_event_task`, `led_status_task`, `decode_reception_task`, `process_outbound_task`, `adc_read_task`, `keypad_task`, `encoder_read_task`, `idle_task` (system/heap info).
+**Tasks monitored:** `cdc_task`, `cdc_write_task`, `uart_event_task`, `led_status_task`, `decode_reception_task`, `process_outbound_task`, `adc_read_task`, `keypad_task` (includes rotary encoder), `idle_task` (system/heap info).
 
 ### 8. Keypad & ADC Monitor
 
@@ -184,21 +184,21 @@ Passively monitors incoming keypad and ADC frames in real-time without sending a
 
 **ADC panel** — one row per active channel:
 
-| Column | Detail |
-|--------|--------|
-| Ch | Channel number (0–15) |
-| Last Value | Most recent 12-bit ADC reading (0–4095), colour-coded green / yellow / red |
-| Trend | Unicode sparkline `▁▂▃▄▅▆▇█` of the last 10 values |
-| Last Updated | UTC timestamp of the most recent sample |
+| Column       | Detail                                                                     |
+| ------------ | -------------------------------------------------------------------------- |
+| Ch           | Channel number (0–15)                                                      |
+| Last Value   | Most recent 12-bit ADC reading (0–4095), colour-coded green / yellow / red |
+| Trend        | Unicode sparkline `▁▂▃▄▅▆▇█` of the last 10 values                         |
+| Last Updated | UTC timestamp of the most recent sample                                    |
 
 **Keypad events panel** — rolling log of the last 20 press/release events, newest first:
 
-| Column | Detail |
-|--------|--------|
-| # | Entry number (1 = most recent) |
-| Time | UTC timestamp (HH:MM:SS.mmm) |
-| Col / Row | Matrix coordinates |
-| State | `PRESSED` (green) or `RELEASED` (dim) |
+| Column    | Detail                                |
+| --------- | ------------------------------------- |
+| #         | Entry number (1 = most recent)        |
+| Time      | UTC timestamp (HH:MM:SS.mmm)          |
+| Col / Row | Matrix coordinates                    |
+| State     | `PRESSED` (green) or `RELEASED` (dim) |
 
 Press **ENTER** to exit back to the main menu.
 
@@ -209,12 +209,12 @@ Press **ENTER** to exit back to the main menu.
 
 Browse JSON files from `test_results/` (paginated, 10 per page) and choose a plot type:
 
-| Key | Plot |
-|-----|------|
-| 1 | Boxplot with dropped-message overlay |
-| 2 | Latency histogram with P95 marker |
-| 3 | Controller health trends |
-| 4 | Error counter details (stacked bar + heatmap) |
+| Key | Plot                                          |
+| --- | --------------------------------------------- |
+| 1   | Boxplot with dropped-message overlay          |
+| 2   | Latency histogram with P95 marker             |
+| 3   | Controller health trends                      |
+| 4   | Error counter details (stacked bar + heatmap) |
 
 Stress run JSON files (`*_stress.json`) are automatically routed to a dedicated three-panel visualization (drop ratio · P95 latency · error counters per scenario).
 
@@ -238,13 +238,13 @@ XOR over all payload bytes (excluding the checksum byte itself).
 
 ### Commands
 
-| Command                   | Value | Description            |
-| ------------------------- | ----- | ---------------------- |
-| `ECHO_COMMAND`            | 20    | Echo test              |
-| `KEY_COMMAND`             | 4     | Keypad event           |
-| `ANALOG_COMMAND`          | 3     | ADC reading            |
-| `STATISTICS_STATUS_COMMAND` | 23 | System statistics poll |
-| `TASK_STATUS_COMMAND`     | 24    | FreeRTOS task poll     |
+| Command                     | Value | Description            |
+| --------------------------- | ----- | ---------------------- |
+| `ECHO_COMMAND`              | 20    | Echo test              |
+| `KEY_COMMAND`               | 4     | Keypad event           |
+| `ANALOG_COMMAND`            | 3     | ADC reading            |
+| `STATISTICS_STATUS_COMMAND` | 23    | System statistics poll |
+| `TASK_STATUS_COMMAND`       | 24    | FreeRTOS task poll     |
 
 ## 🛠️ Development
 

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -61,14 +61,13 @@ TASK_ITEMS = {
     4: "process_outbound_task",
     5: "adc_read_task",
     6: "keypad_task",
-    7: "encoder_read_task",
-    8: "led_status_task",
-    9: "idle_task",
+    7: "led_status_task",
+    8: "idle_task",
 }
 
 # Index of the idle/system slot whose third field carries heap info, not a
 # stack high-watermark.
-IDLE_TASK_INDEX: int = 9
+IDLE_TASK_INDEX: int = 8
 
 # Core affinity for each task (0 or 1), matching include/app_config.h
 TASK_CORE_AFFINITY: dict[str, int] = {
@@ -80,7 +79,6 @@ TASK_CORE_AFFINITY: dict[str, int] = {
     "process_outbound_task": 1,
     "adc_read_task": 1,
     "keypad_task": 1,
-    "encoder_read_task": 1,
     "idle_task": -1,  # not pinned to a core
 }
 
@@ -94,7 +92,6 @@ TASK_STACK_BYTES: dict[str, int] = {
     "process_outbound_task": 3072,
     "adc_read_task": 4096,
     "keypad_task": 5120,
-    "encoder_read_task": 5120,
     "idle_task": 0,  # idle task has no user-allocated stack
 }
 
@@ -156,8 +153,7 @@ TASK_DISPLAY_NAMES: dict[str, str] = {
     "decode_reception_task": "Decode reception",
     "process_outbound_task": "Inbound process",
     "adc_read_task": "ADC read",
-    "keypad_task": "Key read",
-    "encoder_read_task": "Encoder read",
+    "keypad_task": "Key + Encoder read",
     "idle_task": "Idle",
     "led_status_task": "LED status update",
 }

--- a/tests/test_status_mode.py
+++ b/tests/test_status_mode.py
@@ -192,7 +192,6 @@ def test_display_task_status_outputs_table(capsys: pytest.CaptureFixture[str]) -
     sm.task_items[_TASK_INDEX_BY_NAME["cdc_task"]].absolute_time = 10_000
     sm.task_items[_TASK_INDEX_BY_NAME["uart_event_task"]].absolute_time = 20_000
     sm.task_items[_TASK_INDEX_BY_NAME["idle_task"]].absolute_time = 30_000
-    sm.task_items[_TASK_INDEX_BY_NAME["encoder_read_task"]].absolute_time = 40_000
     sm.task_items[_TASK_INDEX_BY_NAME["adc_read_task"]].absolute_time = 50_000
     sm.task_items[_TASK_INDEX_BY_NAME["keypad_task"]].absolute_time = 60_000
     sm.task_items[_TASK_INDEX_BY_NAME["process_outbound_task"]].absolute_time = 70_000
@@ -307,7 +306,6 @@ def test_display_task_status_shows_computed_totals(
     sm.task_items[_TASK_INDEX_BY_NAME["uart_event_task"]].absolute_time = 2_000_000
     sm.task_items[_TASK_INDEX_BY_NAME["led_status_task"]].absolute_time = 100_000
     sm.task_items[_TASK_INDEX_BY_NAME["idle_task"]].absolute_time = 3_000_000
-    sm.task_items[_TASK_INDEX_BY_NAME["encoder_read_task"]].absolute_time = 4_000_000
     sm.task_items[_TASK_INDEX_BY_NAME["adc_read_task"]].absolute_time = 5_000_000
     sm.task_items[_TASK_INDEX_BY_NAME["keypad_task"]].absolute_time = 6_000_000
     sm.task_items[
@@ -325,10 +323,10 @@ def test_display_task_status_shows_computed_totals(
     # formatted as "3,600,000.000"
     assert "3,600,000.000" in out
 
-    # Core 1 = decode + process + adc + keypad + encoder
-    # = 8M + 7M + 5M + 6M + 4M = 30_000_000
-    # formatted as "30,000,000.000"
-    assert "30,000,000.000" in out
+    # Core 1 = decode + process + adc + keypad
+    # = 8M + 7M + 5M + 6M = 26_000_000
+    # formatted as "26,000,000.000"
+    assert "26,000,000.000" in out
 
     # Heap info from idle_task slot should appear
     assert "Min free heap" in out


### PR DESCRIPTION
## Summary

Removes the dedicated `encoder_read_task` from the task model, reflecting the firmware change that merged encoder reading into the keypad task.

### Changes
- **`src/base_test.py`**: Removed `encoder_read_task` from `TASK_ITEMS`, `TASK_CORE_AFFINITY`, `TASK_STACK_BYTES`, and `TASK_DISPLAY_NAMES`. Renamed keypad display to `Key + Encoder read`. Updated `IDLE_TASK_INDEX` from 9 → 8.
- **`tests/test_status_mode.py`**: Removed `encoder_read_task` references and updated Core 1 total assertion (30M → 26M).
- **`README.md`**: Updated documentation to reflect the task list change and added command reference table.

### Test plan
- [x] Existing unit tests pass with updated assertions
- [x] `IDLE_TASK_INDEX` correctly points to index 8
- [x] Core affinity and stack size dicts no longer reference encoder task