### PR TITLE
Add headless runner CLI and non-interactive test APIs with NDJSON feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ uv sync
 uv run src/main.py
 ```
 
+### Headless execution (for .NET/service orchestration)
+
+Use the non-interactive runner when invoking the suite from another process:
+
+```bash
+uv run src/runner_cli.py --mode latency --port /dev/ttyACM0 --baudrate 921600
+uv run src/runner_cli.py --mode baud_sweep --baud-rates 115200,230400,921600
+uv run src/runner_cli.py --mode stress --scenarios echo_burst,mixed_command_burst
+uv run src/runner_cli.py --mode regression --output-json artifacts/regression.json
+uv run src/runner_cli.py --mode stress --feedback-stdout --feedback-interval-ms 250
+uv run src/runner_cli.py --mode latency --feedback-jsonl artifacts/progress.jsonl
+```
+
+The runner prints a JSON summary to stdout and can optionally write it to `--output-json`.
+When a mode generates a report file, the summary includes `result_file` with the absolute path.
+For real-time integration (e.g. .NET), enable `--feedback-stdout` to receive NDJSON progress
+events (`run_started`, `heartbeat`, `mode_started`, `stress_progress`, `mode_finished`,
+`run_finished`) or write them to a file using `--feedback-jsonl`.
+Additionally, each runner invocation always writes a final envelope JSON file to `test_results/`
+and exposes that path as `summary_file` in the final summary payload.
+
 ### Serial Port Configuration
 
 Edit `src/const.py` to match your device:

--- a/src/baud_rate_test.py
+++ b/src/baud_rate_test.py
@@ -197,3 +197,23 @@ class BaudRateTest(BaseTest):
             logger.info("Baud rate sweep test ended")
         except KeyboardInterrupt:
             logger.info("Test interrupted by user")
+
+    def execute_baud_test_with_options(
+        self,
+        *,
+        baud_rates: list[int],
+        samples: int = DEFAULT_SAMPLES,
+        wait_time: float = DEFAULT_WAIT_TIME,
+        length: int = DEFAULT_MESSAGE_LENGTH,
+    ) -> None:
+        """Run baud sweep non-interactively using explicit arguments."""
+        if self.ser is None:
+            logger.info("No serial port found. Quitting test.")
+            return
+
+        self.baud_rate_test(
+            baud_rates=baud_rates,
+            samples=samples,
+            wait_time=wait_time,
+            length=length,
+        )

--- a/src/latency_test.py
+++ b/src/latency_test.py
@@ -245,3 +245,29 @@ class LatencyTest(BaseTest):
             logger.info("Test ended")
         except KeyboardInterrupt:
             logger.info("Test interrupted by user")
+
+    def execute_test_with_options(  # noqa: PLR0913  # Explicit CLI parity
+        self,
+        *,
+        num_times: int = DEFAULT_NUM_TIMES,
+        max_wait: float = DEFAULT_MAX_WAIT,
+        min_wait: float = DEFAULT_MIN_WAIT,
+        wait_time: float = DEFAULT_WAIT_TIME,
+        samples: int = DEFAULT_SAMPLES,
+        length: int = DEFAULT_MESSAGE_LENGTH,
+        jitter: bool = False,
+    ) -> None:
+        """Run the latency test non-interactively using explicit arguments."""
+        if self.ser is None:
+            logger.info("No serial port found. Quitting test.")
+            return
+
+        self.main_test(
+            num_times=num_times,
+            max_wait=max_wait,
+            min_wait=min_wait,
+            wait_time=wait_time,
+            samples=samples,
+            length=length,
+            jitter=jitter,
+        )

--- a/src/runner_cli.py
+++ b/src/runner_cli.py
@@ -1,0 +1,432 @@
+"""Headless CLI runner for non-interactive test-suite execution."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from baud_rate_test import BaudRateTest
+from const import BAUDRATE, PORT_NAME, TEST_RESULTS_FOLDER, TIMEOUT
+from latency_test import LatencyTest
+from logger_config import setup_logging
+from regression_test import RegressionTest
+from result_format import make_result_envelope, make_result_filename
+from serial_interface import SerialInterface
+from stress_config import StressConfig, default_stress_config, load_stress_config
+from stress_test import StressTest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+RunnerMode = str
+_MODES: tuple[RunnerMode, ...] = ("latency", "baud_sweep", "stress", "regression")
+_DEFAULT_BAUD_RATES = [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
+_RUNNER_SUMMARY_FORMAT = "runner_summary"
+
+
+@dataclass(frozen=True)
+class FeedbackConfig:
+    """Feedback stream options."""
+
+    enabled_stdout: bool
+    jsonl_path: str
+    interval_ms: int
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether at least one feedback sink is enabled."""
+        return self.enabled_stdout or bool(self.jsonl_path.strip())
+
+
+class EventSink:
+    """Thread-safe JSON event sink for stdout and optional JSONL file."""
+
+    def __init__(self, config: FeedbackConfig) -> None:
+        """Initialize sink outputs based on feedback config."""
+        self._config = config
+        self._lock = threading.Lock()
+        self._jsonl_handle = None
+        if config.jsonl_path.strip():
+            path = Path(config.jsonl_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._jsonl_handle = path.open("a", encoding="utf-8")
+
+    def emit(self, event: str, **payload: Any) -> None:
+        """Emit one NDJSON event record."""
+        if not self._config.enabled:
+            return
+        record = {"event": event, "ts": time.time(), **payload}
+        line = json.dumps(record, ensure_ascii=False)
+        with self._lock:
+            if self._config.enabled_stdout:
+                sys.stdout.write(line + "\n")
+                sys.stdout.flush()
+            if self._jsonl_handle:
+                self._jsonl_handle.write(line + "\n")
+                self._jsonl_handle.flush()
+
+    def close(self) -> None:
+        """Close optional JSONL file handle."""
+        if self._jsonl_handle:
+            self._jsonl_handle.close()
+            self._jsonl_handle = None
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether any event output channel is enabled."""
+        return self._config.enabled
+
+
+def _parse_baud_rates(raw: str | None) -> list[int] | None:
+    """Parse comma-separated baud rates from CLI input."""
+    if raw is None or not raw.strip():
+        return None
+    values = [chunk.strip() for chunk in raw.split(",")]
+    return [int(value) for value in values if value]
+
+
+def _parse_scenarios(raw: str | None) -> list[str] | None:
+    """Parse comma-separated scenario names from CLI input."""
+    if raw is None or not raw.strip():
+        return None
+    return [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="runner_cli",
+        description=(
+            "Run SignalBridge tests in headless mode for external orchestration."
+        ),
+    )
+    parser.add_argument("--mode", required=True, choices=_MODES)
+    parser.add_argument("--port", default=PORT_NAME)
+    parser.add_argument("--baudrate", default=BAUDRATE, type=int)
+    parser.add_argument("--timeout", default=TIMEOUT, type=float)
+    parser.add_argument(
+        "--output-json",
+        default="",
+        help="Optional path for writing a final summary JSON document.",
+    )
+
+    # Live feedback options
+    parser.add_argument(
+        "--feedback-stdout",
+        action="store_true",
+        help="Emit structured progress events as NDJSON to stdout.",
+    )
+    parser.add_argument(
+        "--feedback-jsonl",
+        default="",
+        help="Optional JSONL file path for structured progress events.",
+    )
+    parser.add_argument(
+        "--feedback-interval-ms",
+        default=500,
+        type=int,
+        help="Heartbeat interval in milliseconds for periodic progress snapshots.",
+    )
+
+    # Shared test knobs
+    parser.add_argument("--samples", default=255, type=int)
+    parser.add_argument("--message-length", default=10, type=int)
+    parser.add_argument("--wait-time", default=3.0, type=float)
+
+    # Latency mode options
+    parser.add_argument("--num-times", default=5, type=int)
+    parser.add_argument("--max-wait", default=0.1, type=float)
+    parser.add_argument("--min-wait", default=0.0, type=float)
+    parser.add_argument("--jitter", action="store_true")
+
+    # Baud sweep mode options
+    parser.add_argument(
+        "--baud-rates",
+        default="",
+        help="Comma-separated baud rates used by baud_sweep mode.",
+    )
+
+    # Stress mode options
+    parser.add_argument(
+        "--stress-config",
+        default="",
+        help="Optional JSON config file loaded via stress_config.load_stress_config.",
+    )
+    parser.add_argument(
+        "--scenarios",
+        default="",
+        help="Comma-separated scenario names to run in stress mode.",
+    )
+    return parser
+
+
+def _result_files_snapshot() -> set[Path]:
+    out_dir = Path(__file__).parent.parent / TEST_RESULTS_FOLDER
+    if not out_dir.exists():
+        return set()
+    return {p for p in out_dir.glob("*.json") if p.is_file()}
+
+
+def _latest_new_file(before: set[Path], after: set[Path]) -> str | None:
+    candidates = [p for p in after if p not in before]
+    if not candidates:
+        return None
+    newest = max(candidates, key=lambda path: path.stat().st_mtime)
+    return str(newest.resolve())
+
+
+def _load_stress_cfg(path: str) -> StressConfig:
+    if path.strip():
+        return load_stress_config(path)
+    return default_stress_config()
+
+
+def _extract_tester_counters(tester: Any) -> dict[str, Any]:
+    """Return generic counters from tester objects for heartbeat events."""
+    counters: dict[str, Any] = {}
+    sent = getattr(tester, "latency_msg_sent", None)
+    received = getattr(tester, "latency_msg_received", None)
+    if isinstance(sent, dict):
+        counters["latency_sent"] = len(sent)
+    if isinstance(received, dict):
+        counters["latency_received"] = len(received)
+    scenario_results = getattr(tester, "_scenario_results", None)
+    if isinstance(scenario_results, list):
+        counters["scenarios_completed"] = len(scenario_results)
+    return counters
+
+
+def _run_feedback_loop(
+    monitor: FeedbackMonitor,
+) -> None:
+    """Emit periodic heartbeat events while a run is active."""
+    while not monitor.stop_event.wait(monitor.interval_s):
+        tester = monitor.tester_getter()
+        serial_stats = monitor.serial.statistics
+        monitor.sink.emit(
+            "heartbeat",
+            mode=monitor.mode,
+            elapsed_s=round(time.time() - monitor.start_time, 3),
+            bytes_sent=serial_stats.bytes_sent,
+            bytes_received=serial_stats.bytes_received,
+            commands_sent=dict(serial_stats.commands_sent),
+            commands_received=dict(serial_stats.commands_received),
+            **(_extract_tester_counters(tester) if tester is not None else {}),
+        )
+
+
+@dataclass(frozen=True)
+class FeedbackMonitor:
+    """Container for heartbeat loop inputs."""
+
+    serial: SerialInterface
+    tester_getter: Callable[[], Any | None]
+    sink: EventSink
+    stop_event: threading.Event
+    interval_s: float
+    mode: str
+    start_time: float
+
+
+def _run_latency_mode(
+    args: argparse.Namespace, serial: SerialInterface, sink: EventSink
+) -> Any:
+    tester = LatencyTest(serial)
+    sink.emit("mode_started", mode=args.mode)
+    serial.set_message_handler(lambda cmd, data, _raw: tester.handle_message(cmd, data))
+    tester.execute_test_with_options(
+        num_times=args.num_times,
+        max_wait=args.max_wait,
+        min_wait=args.min_wait,
+        wait_time=args.wait_time,
+        samples=args.samples,
+        length=args.message_length,
+        jitter=bool(args.jitter),
+    )
+    sink.emit("mode_finished", mode=args.mode)
+    return tester
+
+
+def _run_baud_mode(
+    args: argparse.Namespace, serial: SerialInterface, sink: EventSink
+) -> Any:
+    tester = BaudRateTest(serial)
+    sink.emit("mode_started", mode=args.mode)
+    serial.set_message_handler(lambda cmd, data, _raw: tester.handle_message(cmd, data))
+    baud_rates = _parse_baud_rates(args.baud_rates)
+    tester.execute_baud_test_with_options(
+        baud_rates=baud_rates or _DEFAULT_BAUD_RATES,
+        samples=args.samples,
+        wait_time=args.wait_time,
+        length=args.message_length,
+    )
+    sink.emit("mode_finished", mode=args.mode)
+    return tester
+
+
+def _run_stress_mode(
+    args: argparse.Namespace, serial: SerialInterface, sink: EventSink
+) -> Any:
+    cfg = _load_stress_cfg(args.stress_config)
+    tester = StressTest(
+        serial,
+        cfg,
+        progress_callback=lambda data: sink.emit(
+            "stress_progress", mode=args.mode, **data
+        ),
+    )
+    sink.emit("mode_started", mode=args.mode)
+    serial.set_message_handler(lambda cmd, data, _raw: tester.handle_message(cmd, data))
+    scenario_names = _parse_scenarios(args.scenarios)
+    result = tester.execute_test_with_options(scenario_names=scenario_names)
+    sink.emit(
+        "mode_finished",
+        mode=args.mode,
+        overall_verdict=(result.overall_verdict if result else None),
+    )
+    return tester
+
+
+def _run_regression_mode(
+    args: argparse.Namespace, serial: SerialInterface, sink: EventSink
+) -> Any:
+    tester = RegressionTest(serial)
+    sink.emit("mode_started", mode=args.mode)
+    serial.set_message_handler(tester.handle_message)
+    tester.execute_test()
+    time.sleep(max(args.wait_time, 0.2))
+    sink.emit("mode_finished", mode=args.mode)
+    return tester
+
+
+def _run_mode(args: argparse.Namespace, sink: EventSink) -> dict[str, Any]:
+    serial = SerialInterface(args.port, args.baudrate, args.timeout)
+    if not serial.open():
+        msg = "Failed to open serial interface."
+        raise RuntimeError(msg)
+
+    before_files = _result_files_snapshot()
+    started_at = time.time()
+    tester_ref: dict[str, Any | None] = {"value": None}
+    feedback_stop = threading.Event()
+    feedback_thread: threading.Thread | None = None
+
+    sink.emit(
+        "run_started",
+        mode=args.mode,
+        port=args.port,
+        baudrate=args.baudrate,
+        timeout=args.timeout,
+    )
+    try:
+        serial.start_reading()
+        if sink.enabled and args.feedback_interval_ms > 0:
+            monitor = FeedbackMonitor(
+                serial=serial,
+                tester_getter=lambda: tester_ref["value"],
+                sink=sink,
+                stop_event=feedback_stop,
+                interval_s=args.feedback_interval_ms / 1000,
+                mode=args.mode,
+                start_time=started_at,
+            )
+            feedback_thread = threading.Thread(
+                target=_run_feedback_loop,
+                args=(monitor,),
+                daemon=True,
+            )
+            feedback_thread.start()
+
+        match args.mode:
+            case "latency":
+                tester_ref["value"] = _run_latency_mode(args, serial, sink)
+            case "baud_sweep":
+                tester_ref["value"] = _run_baud_mode(args, serial, sink)
+            case "stress":
+                tester_ref["value"] = _run_stress_mode(args, serial, sink)
+            case "regression":
+                tester_ref["value"] = _run_regression_mode(args, serial, sink)
+            case _:
+                msg = f"Unsupported mode '{args.mode}'."
+                raise ValueError(msg)
+    finally:
+        feedback_stop.set()
+        if feedback_thread and feedback_thread.is_alive():
+            feedback_thread.join(timeout=1.0)
+        serial.close()
+
+    after_files = _result_files_snapshot()
+    result_file = _latest_new_file(before_files, after_files)
+    finished_at = time.time()
+    summary = {
+        "mode": args.mode,
+        "port": args.port,
+        "baudrate": args.baudrate,
+        "timeout": args.timeout,
+        "duration_s": round(finished_at - started_at, 3),
+        "result_file": result_file,
+    }
+    sink.emit("run_finished", summary=summary)
+    return summary
+
+
+def _write_summary(path: str, summary: dict[str, Any]) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(summary, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+
+def _write_runner_summary_file(summary: dict[str, Any]) -> str:
+    """Persist runner summary to test_results using project naming conventions."""
+    run_id = uuid.uuid4().hex[:8]
+    file_name = make_result_filename("runner", run_id)
+    target = Path(__file__).parent.parent / TEST_RESULTS_FOLDER / file_name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    envelope = make_result_envelope(_RUNNER_SUMMARY_FORMAT, summary)
+    target.write_text(
+        json.dumps(envelope, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    return str(target.resolve())
+
+
+def main() -> int:
+    """Run selected mode and emit summary and optional progress feedback."""
+    parser = _make_parser()
+    args = parser.parse_args()
+    feedback_cfg = FeedbackConfig(
+        enabled_stdout=bool(args.feedback_stdout),
+        jsonl_path=args.feedback_jsonl,
+        interval_ms=max(args.feedback_interval_ms, 0),
+    )
+    sink = EventSink(feedback_cfg)
+    try:
+        summary = _run_mode(args, sink)
+        summary["summary_file"] = _write_runner_summary_file(summary)
+        if args.output_json:
+            _write_summary(args.output_json, summary)
+        # Preserve old behavior when stdout feedback is disabled.
+        if not feedback_cfg.enabled_stdout:
+            sys.stdout.write(json.dumps(summary, ensure_ascii=False) + "\n")
+    except Exception:
+        logger.exception("Headless runner failed")
+        sink.emit("run_failed")
+        return 1
+    finally:
+        sink.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/runner_cli.py
+++ b/src/runner_cli.py
@@ -107,24 +107,77 @@ def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="runner_cli",
         description=(
-            "Run SignalBridge tests in headless mode for external orchestration."
+            "Run SignalBridge tests in headless mode for external orchestration.\n"
+            "Modes that already generate detailed reports (latency/baud_sweep/stress)\n"
+            "continue writing those files under test_results/."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  uv run src/runner_cli.py --mode latency "
+            "--port /dev/ttyACM0 --baudrate 921600\n"
+            "  uv run src/runner_cli.py --mode stress "
+            "--scenarios echo_burst --feedback-stdout\n"
+            "  uv run src/runner_cli.py --mode baud_sweep "
+            "--baud-rates 115200,230400,921600\n"
+            "\n"
+            "Output behavior:\n"
+            "  * Without --feedback-stdout: stdout emits only one "
+            "final JSON summary line.\n"
+            "  * With --feedback-stdout: stdout emits NDJSON progress events.\n"
+            "  * Every run writes summary_file in test_results/.\n"
+            "  * result_file points to the detailed mode artifact when available."
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    required_group = parser.add_argument_group("Required")
+    required_group.add_argument(
+        "--mode",
+        required=True,
+        choices=_MODES,
+        help=(
+            "Test mode to execute.\n"
+            "latency|baud_sweep|stress generate detailed result_file.\n"
+            "regression performs validation without a mode-specific detail file."
         ),
     )
-    parser.add_argument("--mode", required=True, choices=_MODES)
-    parser.add_argument("--port", default=PORT_NAME)
-    parser.add_argument("--baudrate", default=BAUDRATE, type=int)
-    parser.add_argument("--timeout", default=TIMEOUT, type=float)
+
+    serial_group = parser.add_argument_group("Serial connection")
+    serial_group.add_argument(
+        "--port",
+        default=PORT_NAME,
+        help=f"Serial device path (default: {PORT_NAME}).",
+    )
+    serial_group.add_argument(
+        "--baudrate",
+        default=BAUDRATE,
+        type=int,
+        help=f"UART baud rate (default: {BAUDRATE}).",
+    )
+    serial_group.add_argument(
+        "--timeout",
+        default=TIMEOUT,
+        type=float,
+        help=f"Serial read timeout in seconds (default: {TIMEOUT}).",
+    )
     parser.add_argument(
         "--output-json",
         default="",
-        help="Optional path for writing a final summary JSON document.",
+        help=(
+            "Optional path for writing the final summary JSON.\n"
+            "Independent of this option, summary_file is always "
+            "written in test_results/."
+        ),
     )
 
     # Live feedback options
     parser.add_argument(
         "--feedback-stdout",
         action="store_true",
-        help="Emit structured progress events as NDJSON to stdout.",
+        help=(
+            "Emit structured progress events as NDJSON to stdout.\n"
+            "When enabled, stdout no longer emits only the single final summary line."
+        ),
     )
     parser.add_argument(
         "--feedback-jsonl",
@@ -139,30 +192,70 @@ def _make_parser() -> argparse.ArgumentParser:
     )
 
     # Shared test knobs
-    parser.add_argument("--samples", default=255, type=int)
-    parser.add_argument("--message-length", default=10, type=int)
-    parser.add_argument("--wait-time", default=3.0, type=float)
+    shared_group = parser.add_argument_group("Shared test options")
+    shared_group.add_argument(
+        "--samples",
+        default=255,
+        type=int,
+        help="Number of samples/messages where supported (default: 255).",
+    )
+    shared_group.add_argument(
+        "--message-length",
+        default=10,
+        type=int,
+        help="Payload length for modes that send echo traffic (default: 10).",
+    )
+    shared_group.add_argument(
+        "--wait-time",
+        default=3.0,
+        type=float,
+        help=(
+            "Post-burst wait in seconds; also used as minimum regression settle delay."
+        ),
+    )
 
     # Latency mode options
-    parser.add_argument("--num-times", default=5, type=int)
-    parser.add_argument("--max-wait", default=0.1, type=float)
-    parser.add_argument("--min-wait", default=0.0, type=float)
-    parser.add_argument("--jitter", action="store_true")
+    latency_group = parser.add_argument_group("Latency mode options")
+    latency_group.add_argument(
+        "--num-times",
+        default=5,
+        type=int,
+        help="Number of latency iterations (default: 5).",
+    )
+    latency_group.add_argument(
+        "--max-wait",
+        default=0.1,
+        type=float,
+        help="Maximum inter-message delay in seconds (default: 0.1).",
+    )
+    latency_group.add_argument(
+        "--min-wait",
+        default=0.0,
+        type=float,
+        help="Minimum inter-message delay in seconds (default: 0.0).",
+    )
+    latency_group.add_argument(
+        "--jitter",
+        action="store_true",
+        help="Enable random delay jitter inside latency mode.",
+    )
 
     # Baud sweep mode options
-    parser.add_argument(
+    baud_group = parser.add_argument_group("Baud sweep mode options")
+    baud_group.add_argument(
         "--baud-rates",
         default="",
         help="Comma-separated baud rates used by baud_sweep mode.",
     )
 
     # Stress mode options
-    parser.add_argument(
+    stress_group = parser.add_argument_group("Stress mode options")
+    stress_group.add_argument(
         "--stress-config",
         default="",
         help="Optional JSON config file loaded via stress_config.load_stress_config.",
     )
-    parser.add_argument(
+    stress_group.add_argument(
         "--scenarios",
         default="",
         help="Comma-separated scenario names to run in stress mode.",

--- a/src/stress_test.py
+++ b/src/stress_test.py
@@ -38,7 +38,7 @@ from stress_reporter import print_summary, write_json_report
 from ui_console import console
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 from base_test import STATISTICS_ITEMS, TASK_ITEMS
 
@@ -67,12 +67,23 @@ class StressTest(BaseTest):
     """Orchestrate all Phase 1 stress scenarios against the firmware."""
 
     def __init__(
-        self, ser: SerialInterface, config: StressConfig | None = None
+        self,
+        ser: SerialInterface,
+        config: StressConfig | None = None,
+        *,
+        progress_callback: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         """Initialise with a serial interface and optional config (defaults apply)."""
         super().__init__(ser)
         self.config: StressConfig = config or default_stress_config()
         self._scenario_results: list[ScenarioResult] = []
+        self._progress_callback = progress_callback
+
+    def _emit_progress(self, event: str, **payload: Any) -> None:
+        """Invoke progress callback if configured."""
+        if not self._progress_callback:
+            return
+        self._progress_callback({"event": event, **payload})
 
     # ------------------------------------------------------------------
     # Public interface (wired by ApplicationManager)
@@ -106,6 +117,24 @@ class StressTest(BaseTest):
         logger.info("Invalid choice. Running ALL scenarios.")
         return self.config.scenarios
 
+    def _resolve_selected_scenarios(
+        self,
+        scenario_names: Sequence[str] | None = None,
+    ) -> list[ScenarioConfig]:
+        """Resolve scenario selection by optional name list."""
+        if not scenario_names:
+            return self.config.scenarios
+
+        wanted = {name.strip() for name in scenario_names if name.strip()}
+        selected = [cfg for cfg in self.config.scenarios if cfg.name in wanted]
+        if not selected:
+            logger.warning(
+                "No matching stress scenarios found for %s. Running all scenarios.",
+                sorted(wanted),
+            )
+            return self.config.scenarios
+        return selected
+
     def execute_test(self) -> StressRunResult | None:
         """Run configured scenarios interactively and return an aggregated result."""
         if self.ser is None or not self.ser.is_open():
@@ -126,11 +155,86 @@ class StressTest(BaseTest):
         )
 
         self._scenario_results = []
-        for cfg in selected_scenarios:
+        total = len(selected_scenarios)
+        for idx, cfg in enumerate(selected_scenarios, start=1):
+            self._emit_progress(
+                "scenario_started",
+                scenario_name=cfg.name,
+                scenario_index=idx,
+                total_scenarios=total,
+            )
             logger.info("=== Scenario: %s ===", cfg.name)
             result = self._run_scenario(cfg)
             self._scenario_results.append(result)
             logger.info("Scenario '%s' finished: verdict=%s", cfg.name, result.verdict)
+            self._emit_progress(
+                "scenario_finished",
+                scenario_name=cfg.name,
+                scenario_index=idx,
+                total_scenarios=total,
+                verdict=result.verdict,
+                drop_ratio=result.drop_ratio,
+                p95_ms=result.p95_ms,
+            )
+
+        ended_at = datetime.now(UTC).isoformat()
+        overall = aggregate_verdict(self._scenario_results)
+        run_result = StressRunResult(
+            run_id=self._run_id,
+            port=self.ser.port,
+            baudrate=self.ser.baudrate,
+            started_at=started_at,
+            ended_at=ended_at,
+            scenarios=self._scenario_results,
+            overall_verdict=overall,
+        )
+
+        report_path = write_json_report(run_result, self.config.output_dir)
+        logger.info("JSON report: %s", report_path)
+        print_summary(run_result)
+        return run_result
+
+    def execute_test_with_options(
+        self,
+        *,
+        scenario_names: Sequence[str] | None = None,
+    ) -> StressRunResult | None:
+        """Run configured scenarios non-interactively and return the aggregate."""
+        if self.ser is None or not self.ser.is_open():
+            logger.info("No serial port found. Quitting test.")
+            return None
+
+        selected_scenarios = self._resolve_selected_scenarios(scenario_names)
+
+        started_at = datetime.now(UTC).isoformat()
+        logger.info(
+            "Starting stress run %s — %d scenario(s)",
+            self._run_id,
+            len(selected_scenarios),
+        )
+
+        self._scenario_results = []
+        total = len(selected_scenarios)
+        for idx, cfg in enumerate(selected_scenarios, start=1):
+            self._emit_progress(
+                "scenario_started",
+                scenario_name=cfg.name,
+                scenario_index=idx,
+                total_scenarios=total,
+            )
+            logger.info("=== Scenario: %s ===", cfg.name)
+            result = self._run_scenario(cfg)
+            self._scenario_results.append(result)
+            logger.info("Scenario '%s' finished: verdict=%s", cfg.name, result.verdict)
+            self._emit_progress(
+                "scenario_finished",
+                scenario_name=cfg.name,
+                scenario_index=idx,
+                total_scenarios=total,
+                verdict=result.verdict,
+                drop_ratio=result.drop_ratio,
+                p95_ms=result.p95_ms,
+            )
 
         ended_at = datetime.now(UTC).isoformat()
         overall = aggregate_verdict(self._scenario_results)

--- a/tests/test_baud_rate_test.py
+++ b/tests/test_baud_rate_test.py
@@ -336,3 +336,21 @@ def test_execute_baud_test_keyboard_interrupt() -> None:
     ):
         # Should not raise; the function catches KeyboardInterrupt internally
         tester.execute_baud_test()
+
+
+def test_execute_baud_test_with_options_calls_baud_rate_test() -> None:
+    """execute_baud_test_with_options delegates to baud_rate_test."""
+    tester = BaudRateTest(Mock(spec=SerialInterface))
+    with patch.object(tester, "baud_rate_test") as mock_sweep:
+        tester.execute_baud_test_with_options(
+            baud_rates=[9600, 115200],
+            samples=12,
+            wait_time=0.2,
+            length=8,
+        )
+    mock_sweep.assert_called_once_with(
+        baud_rates=[9600, 115200],
+        samples=12,
+        wait_time=0.2,
+        length=8,
+    )

--- a/tests/test_latency_test.py
+++ b/tests/test_latency_test.py
@@ -270,6 +270,30 @@ def test_execute_test_no_serial_logs_and_returns(
     assert "No serial port found. Quitting test." in caplog.text
 
 
+def test_execute_test_with_options_calls_main_test() -> None:
+    """execute_test_with_options delegates to main_test with explicit args."""
+    tester = LatencyTest(Mock(spec=SerialInterface))
+    with patch.object(tester, "main_test") as mock_main:
+        tester.execute_test_with_options(
+            num_times=2,
+            max_wait=0.2,
+            min_wait=0.05,
+            wait_time=1.0,
+            samples=10,
+            length=8,
+            jitter=True,
+        )
+    mock_main.assert_called_once_with(
+        num_times=2,
+        max_wait=0.2,
+        min_wait=0.05,
+        wait_time=1.0,
+        samples=10,
+        length=8,
+        jitter=True,
+    )
+
+
 def test_main_test_collects_and_writes_output() -> None:
     """main_test runs loops, computes bitrate, and writes output via helper."""
     mock_ser = Mock(spec=SerialInterface)

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -11,6 +11,7 @@ from runner_cli import (
     FeedbackConfig,
     _extract_tester_counters,
     _latest_new_file,
+    _make_parser,
     _parse_baud_rates,
     _parse_scenarios,
     _write_runner_summary_file,
@@ -93,3 +94,12 @@ def test_write_runner_summary_file_creates_envelope(tmp_path: Path) -> None:
     data = json.loads(Path(out_path).read_text(encoding="utf-8"))
     assert data["format_type"] == "runner_summary"
     assert data["payload"]["mode"] == "latency"
+
+
+def test_parser_help_contains_examples_and_output_notes() -> None:
+    """CLI help includes examples and output behavior guidance."""
+    parser = _make_parser()
+    help_text = parser.format_help()
+    assert "Examples:" in help_text
+    assert "Output behavior:" in help_text
+    assert "--feedback-stdout" in help_text

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -1,0 +1,95 @@
+"""Tests for headless CLI helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+from runner_cli import (
+    EventSink,
+    FeedbackConfig,
+    _extract_tester_counters,
+    _latest_new_file,
+    _parse_baud_rates,
+    _parse_scenarios,
+    _write_runner_summary_file,
+)
+
+
+def test_parse_baud_rates_with_values() -> None:
+    """Parses comma-separated baud rates into integers."""
+    assert _parse_baud_rates("9600, 115200,230400") == [9600, 115200, 230400]
+
+
+def test_parse_baud_rates_empty_returns_none() -> None:
+    """Returns None when no baud rates are provided."""
+    assert _parse_baud_rates("") is None
+
+
+def test_parse_scenarios_with_values() -> None:
+    """Parses comma-separated scenario names."""
+    assert _parse_scenarios("echo_burst, mixed_command_burst") == [
+        "echo_burst",
+        "mixed_command_burst",
+    ]
+
+
+def test_parse_scenarios_empty_returns_none() -> None:
+    """Returns None when no scenario names are provided."""
+    assert _parse_scenarios(" ") is None
+
+
+def test_latest_new_file_returns_newest_created_path(tmp_path: Path) -> None:
+    """Picks newest file from the new-file delta set."""
+    existing = tmp_path / "old.json"
+    existing.write_text("{}", encoding="utf-8")
+    before = {existing}
+
+    file_a = tmp_path / "a.json"
+    file_a.write_text("{}", encoding="utf-8")
+    file_b = tmp_path / "b.json"
+    file_b.write_text("{}", encoding="utf-8")
+    after = {existing, file_a, file_b}
+
+    newest = _latest_new_file(before, after)
+    assert newest in {str(file_a.resolve()), str(file_b.resolve())}
+
+
+def test_extract_tester_counters_with_latency_fields() -> None:
+    """Extracts sent/received counters from tester-like objects."""
+    tester = Mock()
+    tester.latency_msg_sent = {0: 1.0, 1: 2.0}
+    tester.latency_msg_received = {0: 1.0}
+    tester._scenario_results = ["x"]
+    counters = _extract_tester_counters(tester)
+    assert counters["latency_sent"] == 2
+    assert counters["latency_received"] == 1
+    assert counters["scenarios_completed"] == 1
+
+
+def test_event_sink_writes_jsonl(tmp_path: Path) -> None:
+    """EventSink writes structured JSON lines to output file."""
+    out = tmp_path / "events.jsonl"
+    sink = EventSink(
+        FeedbackConfig(enabled_stdout=False, jsonl_path=str(out), interval_ms=250)
+    )
+    sink.emit("heartbeat", mode="latency", elapsed_s=1.2)
+    sink.close()
+    lines = out.read_text(encoding="utf-8").strip().splitlines()
+    payload = json.loads(lines[0])
+    assert payload["event"] == "heartbeat"
+    assert payload["mode"] == "latency"
+
+
+def test_write_runner_summary_file_creates_envelope(tmp_path: Path) -> None:
+    """Runner summary file is generated using metadata envelope."""
+    summary = {"mode": "latency", "result_file": str(tmp_path / "result.json")}
+    from runner_cli import __file__ as runner_file
+
+    base = Path(runner_file).parent.parent / "test_results"
+    base.mkdir(parents=True, exist_ok=True)
+    out_path = _write_runner_summary_file(summary)
+    data = json.loads(Path(out_path).read_text(encoding="utf-8"))
+    assert data["format_type"] == "runner_summary"
+    assert data["payload"]["mode"] == "latency"

--- a/tests/test_stress_test.py
+++ b/tests/test_stress_test.py
@@ -680,3 +680,59 @@ class TestFaultInjection:
         tester = self._make_fi_tester(mock_serial, [b"\x01\x00"])
         result = tester._run_fault_injection(tester.config.scenarios[0])
         assert isinstance(result, ScenarioResult)
+
+
+def test_resolve_selected_scenarios_filters_by_name(mock_serial: Mock) -> None:
+    """_resolve_selected_scenarios keeps only requested scenario names."""
+    tester = _make_tester(mock_serial, default_stress_config())
+    selected = tester._resolve_selected_scenarios(["echo_burst", "fi_bad_checksum"])
+    assert [cfg.name for cfg in selected] == ["echo_burst", "fi_bad_checksum"]
+
+
+def test_execute_test_with_options_uses_selected_scenarios(mock_serial: Mock) -> None:
+    """execute_test_with_options runs only provided scenarios."""
+    tester = _make_tester(mock_serial, default_stress_config())
+    with (
+        patch.object(tester, "_run_scenario") as mock_run,
+        patch("stress_test.write_json_report"),
+        patch("stress_test.print_summary"),
+    ):
+        mock_result = Mock()
+        mock_result.verdict = "PASS"
+        mock_run.return_value = mock_result
+        tester.execute_test_with_options(scenario_names=["echo_burst"])
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0].name == "echo_burst"
+
+
+def test_execute_test_with_options_emits_progress_events(mock_serial: Mock) -> None:
+    """StressTest emits scenario start/finish events through callback."""
+    events: list[dict[str, Any]] = []
+    tester = StressTest(
+        mock_serial,
+        default_stress_config(),
+        progress_callback=lambda evt: events.append(evt),
+    )
+    tester._request_status_snapshot = Mock(
+        return_value={
+            "statistics": {},
+            "tasks": {},
+            "received": {"statistics": 0, "tasks": 0},
+            "complete": False,
+        }
+    )
+    tester._calculate_status_delta = Mock(return_value={"statistics": {}, "tasks": {}})
+    with (
+        patch.object(tester, "_run_scenario") as mock_run,
+        patch("stress_test.write_json_report"),
+        patch("stress_test.print_summary"),
+    ):
+        mock_result = Mock()
+        mock_result.verdict = "PASS"
+        mock_result.drop_ratio = 0.0
+        mock_result.p95_ms = 1.0
+        mock_run.return_value = mock_result
+        tester.execute_test_with_options(scenario_names=["echo_burst"])
+
+    assert any(evt["event"] == "scenario_started" for evt in events)
+    assert any(evt["event"] == "scenario_finished" for evt in events)


### PR DESCRIPTION
### Motivation
- Enable automated, non-interactive execution of the test-suite for external orchestration (CI/.NET/service integration) and provide structured progress events.
- Provide programmatic parity between interactive test flows and headless invocation so test scenarios can be driven without a TTY.

### Description
- Add `src/runner_cli.py`, a headless CLI that supports `--mode` (latency|baud_sweep|stress|regression`), NDJSON/JSONL progress events, periodic heartbeats, and final summary files written into `test_results/`.
- Add non-interactive entrypoints `execute_baud_test_with_options`, `execute_test_with_options`, and `execute_test_with_options` on `BaudRateTest`, `LatencyTest`, and `StressTest` respectively, which delegate to existing core test logic using explicit args.
- Extend `StressTest` with a `progress_callback` hook, scenario name resolution (`_resolve_selected_scenarios`), and emission of `scenario_started`/`scenario_finished` progress events when running non-interactively.
- Update `README.md` with a new "Headless execution" section demonstrating `uv run src/runner_cli.py` usage and feedback options, and add tests to validate the new CLI and non-interactive APIs.

### Testing
- Added and updated unit tests: `tests/test_runner_cli.py`, `tests/test_baud_rate_test.py`, `tests/test_latency_test.py`, and `tests/test_stress_test.py` to cover parsing, event sinking, and the new `execute_*_with_options` and progress callback behavior.
- Ran the test suite with `pytest` against the modified modules and the new tests, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed4070c7a8832fbb9c2edd67087457)