### PR TITLE
Configure project packaging for PyPI distribution and external installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,32 @@ uv sync
 uv run src/main.py
 ```
 
-### Install from PyPI (for external orchestrators)
+### Build/Publish with uv (PyPI)
 
-After publishing to PyPI, install with `pip` in any external program/runtime:
+To keep the workflow 100% in `uv`, build and publish with:
 
 ```bash
-pip install signalbridge-test-suite
+uv build
+uv publish
+```
+
+### Install from PyPI (for external orchestrators)
+
+After publishing to PyPI, install in external runtimes with `uv` (recommended) or `pip`:
+
+```bash
+uv tool install signalbridge-test-suite
 signalbridge-test-suite
 signalbridge-runner --mode latency --port /dev/ttyACM0 --baudrate 921600
 ```
 
-You can also invoke module entry points directly:
+Equivalent `pip` install:
+
+```bash
+pip install signalbridge-test-suite
+```
+
+You can also invoke module entry points directly (for embedded invocations):
 
 ```bash
 python -m main

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ uv sync
 uv run src/main.py
 ```
 
+### Install from PyPI (for external orchestrators)
+
+After publishing to PyPI, install with `pip` in any external program/runtime:
+
+```bash
+pip install signalbridge-test-suite
+signalbridge-test-suite
+signalbridge-runner --mode latency --port /dev/ttyACM0 --baudrate 921600
+```
+
+You can also invoke module entry points directly:
+
+```bash
+python -m main
+python -m runner_cli --mode regression
+```
+
 ### Headless execution (for .NET/service orchestration)
 
 Use the non-interactive runner when invoking the suite from another process:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dev = [
 [tool.setuptools]
 package-dir = {"" = "src"}
 py-modules = [
-    "__init__",
     "application_manager",
     "base_test",
     "baud_rate_test",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,69 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "signalbridge-test-suite"
 version = "0.1.0"
 description = "SignalBridge Test Suite"
 readme = "README.md"
+license = "GPL-3.0-or-later"
+authors = [{ name = "SignalBridge contributors" }]
 requires-python = ">=3.13"
 dependencies = [
     "alive-progress==3.3.0",
     "cobs==1.2.2",
     "matplotlib>=3.10.8",
     "numpy>=2.2.1",
-    "pre-commit==4.6.0",
     "pyserial==3.5",
     "rich>=13.9.0",
-    "ruff==0.15.12",
 ]
+
+[project.urls]
+Repository = "https://github.com/carlosmazzei/signalbridge-test-suite"
+Issues = "https://github.com/carlosmazzei/signalbridge-test-suite/issues"
+
+[project.scripts]
+signalbridge-test-suite = "main:main"
+signalbridge-runner = "runner_cli:main"
 
 [dependency-groups]
 dev = [
     "coverage>=7.5",
     "hypothesis>=6.112.0",
     "mutmut>=3.2.2",
+    "pre-commit==4.6.0",
     "pytest>=8.3.3",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest-timeout>=2.3.1",
+    "ruff==0.15.12",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = [
+    "__init__",
+    "application_manager",
+    "base_test",
+    "baud_rate_test",
+    "checksum",
+    "command_mode",
+    "const",
+    "fault_frames",
+    "keypad_adc_monitor",
+    "latency_test",
+    "logger_config",
+    "main",
+    "regression_test",
+    "result_format",
+    "runner_cli",
+    "serial_interface",
+    "status_mode",
+    "stress_config",
+    "stress_evaluator",
+    "stress_reporter",
+    "stress_test",
+    "ui_console",
+    "visualize_results",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -912,16 +912,14 @@ wheels = [
 [[package]]
 name = "signalbridge-test-suite"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "alive-progress" },
     { name = "cobs" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "pre-commit" },
     { name = "pyserial" },
     { name = "rich" },
-    { name = "ruff" },
 ]
 
 [package.dev-dependencies]
@@ -929,10 +927,12 @@ dev = [
     { name = "coverage" },
     { name = "hypothesis" },
     { name = "mutmut" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -941,10 +941,8 @@ requires-dist = [
     { name = "cobs", specifier = "==1.2.2" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.2.1" },
-    { name = "pre-commit", specifier = "==4.6.0" },
     { name = "pyserial", specifier = "==3.5" },
     { name = "rich", specifier = ">=13.9.0" },
-    { name = "ruff", specifier = "==0.15.12" },
 ]
 
 [package.metadata.requires-dev]
@@ -952,10 +950,12 @@ dev = [
     { name = "coverage", specifier = ">=7.5" },
     { name = "hypothesis", specifier = ">=6.112.0" },
     { name = "mutmut", specifier = ">=3.2.2" },
+    { name = "pre-commit", specifier = "==4.6.0" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "ruff", specifier = "==0.15.12" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation

- Make the repository publishable and installable from PyPI so external orchestrators can `pip install` and run the suite as a CLI tool.
- Provide easy programmatic invocation by adding console entry points for both the interactive suite and headless runner.
- Separate development-only tools (formatters/hooks) from runtime dependencies so installed packages are leaner and buildable.

### Description

- Add a PEP 517 build backend block (`[build-system]`) and configure `setuptools` metadata in `pyproject.toml` to enable sdist/wheel builds.
- Add `license`, `authors`, `project.urls` and `project.scripts` with two console entry points: `signalbridge-test-suite = "main:main"` and `signalbridge-runner = "runner_cli:main"`.
- Move `pre-commit` and `ruff` to the `dependency-groups.dev` section and declare `tool.setuptools` with `package-dir = {"" = "src"}` and `py-modules` listing so top-level modules in `src/` install correctly.
- Update `README.md` with a PyPI install section and example invocations, and refresh `uv.lock` to reflect the dependency and metadata changes.

### Testing

- Ran unit tests with `uv run pytest -q`, which passed (`599 passed, 1 warning`).
- Attempted `uv run python -m build`, which failed because the local environment lacked the `build` module (expected environment issue).
- Built artifacts successfully with `uv run --with build python -m build`, producing both `.tar.gz` and `.whl` outputs via the PEP 517 flow.
- Installed the generated wheel and exercised the runner CLI help with `uv run --with ./dist/signalbridge_test_suite-0.1.0-py3-none-any.whl signalbridge-runner --help`, which displayed the expected usage text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef36e48f68832f865d653436be9591)