### PR TITLE
docs: consolidate documentation into docs/ and fix cohesion issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ SignalBridge Test Suite is a Python application for testing a SignalBridge embed
 
 ## Common Commands
 
+The full command reference (build/publish, headless runner, troubleshooting) lives
+in [README.md](README.md). The essentials:
+
 ```bash
 # Install dependencies
 uv sync
@@ -35,22 +38,20 @@ uv run mutmut run
 
 ## Architecture
 
-**CRITICAL REFERENCE: See [ARCHITECTURE.md](ARCHITECTURE.md) for authoritative architectural rules.**
+**CRITICAL REFERENCE: See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for authoritative architectural rules.** A documentation index is available at [docs/README.md](docs/README.md).
 
-All code modifications and new feature implementations must strictly adhere to the patterns, layers, and constraints described in `ARCHITECTURE.md`. You must consult it before creating new test modes or adjusting the communication stack. This includes:
+All code modifications and new feature implementations must strictly adhere to the patterns, layers, and constraints described in `docs/ARCHITECTURE.md`. You must consult it before creating new test modes or adjusting the communication stack. This includes:
 - Layer overview and orchestration via `ApplicationManager`
 - Base classes like `BaseTest` and protocol implementations
 - Buffer, Flow Control, and Thread Safety paradigms
 
 ## Code Conventions
 
-- **Always check if linter and ruff check are passing before proceeding.** Make sure to suppress only the minimal things.
-- **Always check if the tests are passing** before concluding a task.
-- **Python 3.13** target (ruff config, CI)
-- **ruff** with `select = ["ALL"]` — all lint rules enabled, specific ignores in `ruff.toml`
-- Type hints on all functions and class attributes
-- Tests use pytest-style `assert` with `unittest.mock` for hardware mocking
-- `tests/conftest.py` forces matplotlib `Agg` backend for headless CI
-- Thread safety: `_status_lock` (threading.Lock) guards shared statistics/task dicts in `BaseTest`
-- Test results written to `test_results/` as JSON
+The authoritative conventions are in [docs/ARCHITECTURE.md §9](docs/ARCHITECTURE.md#9-code-conventions)
+(Python 3.13, ruff `select = ["ALL"]`, type hints, threading, logging). Beyond
+those, when working in this repository:
+
+- **Always check that the linter and `ruff check` are passing before proceeding.** Suppress only the minimal things.
+- **Always check that the tests are passing** before concluding a task.
+- `tests/conftest.py` forces the matplotlib `Agg` backend for headless CI.
 - Pre-commit hooks run ruff lint+format and pytest on every commit. `mutmut` is a manual-stage hook (see `.pre-commit-config.yaml`) invoked on demand with `pre-commit run mutmut --hook-stage manual` or `uv run mutmut run`.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,25 @@ Polls and displays FreeRTOS statistics and task performance in Rich tables.
 
 **Tasks monitored:** `cdc_task`, `cdc_write_task`, `uart_event_task`, `led_status_task`, `decode_reception_task`, `process_outbound_task`, `adc_read_task`, `keypad_task` (includes rotary encoder), `idle_task` (system/heap info).
 
+### 7. Visualize Test Results
+
+Browse JSON files from `test_results/` (paginated, 10 per page) and choose a plot type:
+
+| Key | Plot                                          |
+| --- | --------------------------------------------- |
+| 1   | Boxplot with dropped-message overlay          |
+| 2   | Latency histogram with P95 marker             |
+| 3   | Controller health trends                      |
+| 4   | Error counter details (stacked bar + heatmap) |
+
+Stress run JSON files (`*_stress.json`) are automatically routed to a dedicated three-panel visualization (drop ratio · P95 latency · error counters per scenario).
+
+**Example output:**
+
+| Boxplot | Histogram | Controller health |
+| ------- | --------- | ----------------- |
+| ![Latency boxplot with dropped-message overlay](assets/boxplot.png) | ![Latency histogram with P95 marker](assets/histogram.png) | ![Controller health trends](assets/controller_health.png) |
+
 ### 8. Keypad & ADC Monitor
 
 Passively monitors incoming keypad and ADC frames in real-time without sending any commands to the device. The display auto-refreshes at 2 Hz using a live Rich panel.
@@ -259,19 +278,6 @@ Press **ENTER** to exit back to the main menu.
 
 > [!NOTE]
 > The ADC task on the firmware runs continuously, so values update frequently. The keypad panel only appends an entry when a key state changes (press or release).
-
-### 9. Visualize Test Results
-
-Browse JSON files from `test_results/` (paginated, 10 per page) and choose a plot type:
-
-| Key | Plot                                          |
-| --- | --------------------------------------------- |
-| 1   | Boxplot with dropped-message overlay          |
-| 2   | Latency histogram with P95 marker             |
-| 3   | Controller health trends                      |
-| 4   | Error counter details (stacked bar + heatmap) |
-
-Stress run JSON files (`*_stress.json`) are automatically routed to a dedicated three-panel visualization (drop ratio · P95 latency · error counters per scenario).
 
 ## 🔧 Protocol Reference
 
@@ -308,7 +314,8 @@ XOR over all payload bytes (excluding the checksum byte itself).
 ```
 signalbridge-test-suite/
 ├── src/
-│   ├── main.py                # Entry point
+│   ├── main.py                # Entry point (interactive menu)
+│   ├── runner_cli.py          # Non-interactive CLI runner (CI / orchestration)
 │   ├── application_manager.py # Menu loop and module orchestration
 │   ├── base_test.py           # Shared BaseTest infrastructure
 │   ├── latency_test.py        # Latency measurement
@@ -330,13 +337,15 @@ signalbridge-test-suite/
 │   ├── logger_config.py       # Logging setup
 │   └── const.py               # Serial port / folder constants
 ├── tests/                     # pytest test suite
-├── docs/                      # Additional documentation
+├── docs/                      # Documentation (see docs/README.md index)
+│   ├── README.md              # Documentation index
+│   ├── ARCHITECTURE.md        # Authoritative architectural rules
+│   └── firmware_stress_test_plan.md
 ├── test_results/              # JSON output from test runs
 ├── pyproject.toml             # Dependencies and tool config
 ├── ruff.toml                  # Ruff linter/formatter config
 ├── pytest.ini                 # pytest configuration
-├── logging_config.ini         # Logging configuration
-└── ARCHITECTURE.md            # Authoritative architectural rules
+└── logging_config.ini         # Logging configuration
 ```
 
 ### Common Commands
@@ -372,7 +381,7 @@ uv run mutmut run
 
 ### Adding a New Test Mode
 
-1. Subclass `BaseTest` (see `ARCHITECTURE.md` for mandatory patterns):
+1. Subclass `BaseTest` (see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for mandatory patterns):
 
    ```python
    # src/my_test.py
@@ -389,13 +398,17 @@ uv run mutmut run
 
 ### Code Conventions
 
-- **Python 3.13** target
-- **ruff** with `select = ["ALL"]` — all lint rules enabled; specific ignores in `ruff.toml`
-- Type hints on all functions and class attributes
-- Thread safety: `_status_lock` (threading.Lock) guards shared dicts in `BaseTest`
-- Tests use pytest-style `assert` with `unittest.mock` for hardware mocking
-- Test results written to `test_results/` as JSON
-- Pre-commit hooks run ruff lint + format and pytest on every commit. `mutmut` is a manual-stage hook (`pre-commit run mutmut --hook-stage manual`) and is not invoked by a plain `git commit`.
+The full, authoritative conventions live in
+[docs/ARCHITECTURE.md §9](docs/ARCHITECTURE.md#9-code-conventions). In short:
+
+- **Python 3.13** target, **ruff** with `select = ["ALL"]` (ignores in `ruff.toml`).
+- Type hints on all functions and class attributes.
+- Thread safety: `_status_lock` (threading.Lock) guards shared dicts in `BaseTest`.
+- Tests use pytest-style `assert` with `unittest.mock` for hardware mocking;
+  results are written to `test_results/` as JSON.
+- Pre-commit hooks run ruff lint + format and pytest on every commit. `mutmut` is
+  a manual-stage hook (`pre-commit run mutmut --hook-stage manual`) and is not
+  invoked by a plain `git commit`.
 
 ## 🚨 Troubleshooting
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,8 @@
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│                     main.py                         │  Entry point
+│            main.py  ·  runner_cli.py                 │  Entry points
+│       (interactive menu)  (non-interactive CLI)     │
 ├─────────────────────────────────────────────────────┤
 │               ApplicationManager                    │  Orchestration
 │   (Mode enum, ModuleConfig, menu, message routing)  │
@@ -219,6 +220,9 @@ These constants are class attributes on `SerialInterface` and must not be duplic
 
 ## 9. Code Conventions
 
+> This section is the **single source of truth** for code conventions. `README.md`
+> and `CLAUDE.md` keep only short summaries that link back here.
+
 ### Python version and tooling
 
 - Target: **Python 3.13**. Use `from __future__ import annotations` at the top of every module to enable PEP 563 postponed evaluation of annotations.
@@ -288,7 +292,8 @@ def serial_interface():
 ## 11. Dependency Graph (import direction)
 
 ```
-main.py
+main.py            (interactive entry point)
+runner_cli.py      (non-interactive entry point — CI / external orchestration)
 └── application_manager.py
     ├── serial_interface.py ──► checksum.py
     │                       ──► logger_config.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Documentation Index
+
+This folder collects the project documentation for the SignalBridge Test Suite.
+Start with the user guide, then dive into the architecture reference for
+implementation rules.
+
+| Document | Audience | Purpose |
+| --- | --- | --- |
+| [../README.md](../README.md) | Users & operators | Quick start, feature tour, usage guide for every test mode, protocol reference, troubleshooting. **Entry point.** |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Contributors | Authoritative architectural rules — layers, module registration, threading model, serial protocol, and the canonical **Code Conventions**. Read before changing code. |
+| [firmware_stress_test_plan.md](firmware_stress_test_plan.md) | Contributors | Roadmap for hardening firmware robustness validation, with current status per phase. |
+| [../CLAUDE.md](../CLAUDE.md) | Claude Code | Orientation for AI-assisted development; defers to `ARCHITECTURE.md` for the detailed rules. |
+
+## Conventions for this repository
+
+- **Code conventions** live in a single place: [ARCHITECTURE.md §9](ARCHITECTURE.md#9-code-conventions).
+- **Common commands** (install, test, lint, mutation testing) live in
+  [../README.md](../README.md) under *Development*.
+- Other documents link to those sources instead of duplicating them, so there is
+  one place to update.


### PR DESCRIPTION
- Move ARCHITECTURE.md into docs/ and add docs/README.md as an index
- Reference previously orphaned assets/*.png chart examples in the README
  visualization section
- Fix broken Usage Guide numbering (sections now run 1-8 and match the menu;
  Visualize is item 7, Keypad item 8)
- Document the runner_cli.py non-interactive entry point in ARCHITECTURE.md
  (layer overview + dependency graph) and the README project structure
- Reduce duplication: ARCHITECTURE.md §9 is now the single source of truth for
  code conventions and the README owns common commands; CLAUDE.md cross-links
- Update all ARCHITECTURE.md references to docs/ARCHITECTURE.md

https://claude.ai/code/session_015miMQPE8s8wqmhmkpetKLB