### PR TITLE
Fix execution-breaking bugs, data races, and resilience gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode
 .DS_Store
 .claude
+.cognition/
 .mutmut-cache*
 
 # Remove test results folder

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,12 +118,32 @@ Every test mode that communicates with the device **must** extend `BaseTest` (`s
 | `_write_output_to_file(path, data)` | Serialize results list to JSON |
 | `_request_status_snapshot(timeout_s)` | Poll all 22 statistics + 10 task items; return `{statistics, tasks, received, complete}` |
 | `_calculate_status_delta(before, after)` | Compute counter deltas between two snapshots |
-| `_get_user_input(prompt, default_value)` | Prompt with default, auto-cast to `type(default_value)` |
+| `_get_user_input(prompt, default_value)` | Prompt with default, auto-cast to `type(default_value)`; `bool` defaults are parsed by word and an unconvertible entry falls back to the default |
 | `_status_lock` | `threading.Lock` — always acquire before reading/writing `_statistics_values` or `_task_values` |
+| `_latency_lock` | `threading.Lock` — guards `latency_msg_sent` / `latency_msg_received` |
+| `_latency_snapshot()` | Returns `(latencies, sent_count, received_count)` copied under `_latency_lock` |
+| `_reset_latency()` | Clears both latency dicts under `_latency_lock` |
 
 ### Thread-safety rule
 
 `handle_message` is called from the **processing thread**. Every write to `_statistics_values` or `_task_values` must be done inside `with self._status_lock:`. Reads of those dicts in the main thread must also be inside the lock.
+
+The same rule applies to the latency dictionaries under `_latency_lock`.
+Test modes must **not** read `latency_msg_sent` / `latency_msg_received`
+directly — iterating them while a late echo arrives raises
+`RuntimeError: dictionary changed size during iteration`. Use
+`_latency_snapshot()` to read and `_reset_latency()` to clear.
+
+`SerialStatistics` owns its own lock. Its counters are written by the read
+thread (`bytes_received`) and the processing thread (`commands_received`)
+while the main thread — and, under the headless runner, the heartbeat thread
+— reads them. Mutate only through its `record_*` methods and read only via
+`snapshot()`; never iterate the live `commands_sent` / `commands_received`
+dictionaries.
+
+`SerialInterface.write()` and `write_raw()` share `_write_lock`, so concurrent
+producers (echo publisher, status pollers, raw fault injection) cannot
+interleave bytes mid-frame.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,6 +145,30 @@ dictionaries.
 producers (echo publisher, status pollers, raw fault injection) cannot
 interleave bytes mid-frame.
 
+### Status snapshot cost
+
+`_request_status_snapshot()` paces one request per item, so its floor is set by
+the number of items, not by how fast the device answers. Pass
+`include_tasks=False` when only `status_delta` is consumed — it skips the
+per-task round-trips entirely. Scenarios that snapshot in a loop should carry
+each "after" snapshot over as the next iteration's "before" rather than polling
+twice per step; `_run_fault_injection` is the reference for both.
+
+### Flow control
+
+RTS backpressure is driven by `message_queue.qsize()` against
+`QUEUE_HIGH_WATER` / `QUEUE_LOW_WATER`, i.e. by how far the processing thread
+has fallen behind. Do **not** measure it on `self.buffer`: that is the
+partial-frame accumulator, cleared at every delimiter, so an ordinary ~12-byte
+frame never approaches a byte watermark and flow control would never engage.
+
+### Logging setup
+
+`setup_logging()` configures the process once and ignores later calls. Eight
+modules invoke it at import time, and each real run re-reads the ini file,
+re-opens the handlers, and restarts the `QueueListener` thread. Pass
+`force=True` only for a deliberate reconfiguration.
+
 ---
 
 ## 5. Threading Model

--- a/docs/dotnet_integration.md
+++ b/docs/dotnet_integration.md
@@ -226,19 +226,63 @@ guarantee.
   this as a prerequisite if regression-mode automation is required.
 - **Exit code carries no verdict information** (§4) — always parse the
   summary/result JSON.
-- **Received frames are not checksum-verified by default.** `SerialInterface`
-  takes a `verify_checksum` flag that drops frames whose trailing XOR byte
-  does not match; it defaults to `False` because the firmware's reply format
-  is not settled in this repo — `command_mode.py` logs a received-vs-computed
-  checksum pair as though replies carry one, while `regression_test.py`
-  compares the decoded echo against the bare payload as though they do not.
-  Until that is confirmed against hardware, a corrupted frame that survives
-  COBS decoding is still counted as a valid echo. The `checksum_mismatches`
-  heartbeat counter (§6) reports how often this happens: a rate near zero
-  means replies are checksummed and the flag can be switched on; a rate near
-  100% means they are not, and the check should stay off.
+- **Frames dropped by checksum verification are invisible to the mode's own
+  counters.** Verification is on (see §10), so a corrupted reply is discarded
+  before it reaches the test mode. It therefore shows up as a *dropped* echo
+  in `drop_ratio`, not as an error — the only direct signal is the
+  `checksum_mismatches` heartbeat counter (§6). When diagnosing an unexpected
+  `drop_ratio`, read that counter before assuming the device failed to reply.
 
-## 9. Keeping this document in sync
+## 9. `--stress-config` file format
+
+The JSON passed to `--stress-config` maps onto `stress_config.StressConfig`.
+Two fields need care:
+
+- **`output_dir`** defaults to `test_results`, matching the built-in config.
+  The runner discovers `result_file` by diffing `test_results/` before and
+  after the run, so pointing this elsewhere makes `result_file` come back
+  `null` even though the report was written.
+- **`fault_frames`** is a list of **recipe names**, not raw bytes — byte
+  sequences cannot round-trip through JSON. Names are resolved against
+  `fault_frames.ALL_RECIPES`: `empty_frame`, `too_short`, `size_mismatch`,
+  `unknown_id`, `bad_checksum`, `payload_overflow`, `single_overflow`,
+  `double_overflow_empty`. An unknown name fails the load with a `ValueError`
+  naming the valid recipes, rather than silently yielding a scenario that
+  injects nothing and then always reports `FAIL` against its
+  `expected_counter_deltas`.
+
+```json
+{
+  "output_dir": "test_results",
+  "scenarios": [
+    {
+      "name": "fi_bad_checksum",
+      "command_profile": "fault_injection",
+      "pacing_s": 0.05,
+      "fault_frames": ["bad_checksum"],
+      "thresholds": {
+        "max_echo_drop_ratio": 1.0,
+        "expected_counter_deltas": {"checksum_error": 1}
+      }
+    }
+  ]
+}
+```
+
+## 10. Receive-path checksum verification
+
+`SerialInterface` verifies the trailing XOR checksum on every decoded frame
+and drops mismatches; the wire format is symmetric
+(`COBS_ENCODE(body + XOR_checksum) + 0x00`) in both directions. Every
+mismatch increments `checksum_mismatches`, reported on each heartbeat (§6).
+
+A dropped frame is never dispatched to the test mode and never counted in
+`commands_received`, so corrupted traffic can no longer inflate latency
+samples or mask a real drop. Construct `SerialInterface(...,
+verify_checksum=False)` to fall back to counting mismatches without dropping —
+useful when bringing up firmware whose reply framing is still changing.
+
+## 11. Keeping this document in sync
 
 This file is a **contract**, not incidental documentation. Whenever a change
 touches the headless surface — `src/runner_cli.py` (CLI flags, stdout

--- a/docs/dotnet_integration.md
+++ b/docs/dotnet_integration.md
@@ -153,7 +153,7 @@ event-specific fields.
 | `event` | Emitted | Key fields |
 | --- | --- | --- |
 | `run_started` | once, before the mode runs | `mode`, `port`, `baudrate`, `timeout` |
-| `heartbeat` | every `--feedback-interval-ms` while active (skipped if interval is `0`) | `mode`, `elapsed_s`, `bytes_sent`, `bytes_received`, `commands_sent` (dict keyed by command id), `commands_received`, plus tester-specific counters when available: `latency_sent`, `latency_received`, `scenarios_completed` |
+| `heartbeat` | every `--feedback-interval-ms` while active (skipped if interval is `0`) | `mode`, `elapsed_s`, `bytes_sent`, `bytes_received`, `commands_sent` (dict keyed by command id), `commands_received`, `dropped_frames`, `checksum_mismatches`, plus tester-specific counters when available: `latency_sent`, `latency_received`, `scenarios_completed` |
 | `mode_started` | once, mode-specific setup complete | `mode` |
 | `stress_progress` | `stress` mode only, per scenario transition | `mode`, `stress_event` (`scenario_started` \| `scenario_finished`), `scenario_name`, `scenario_index`, `total_scenarios`, and on `scenario_finished`: `verdict`, `drop_ratio`, `p95_ms` |
 | `mode_finished` | once, mode work complete | `mode`; `stress` mode also includes `overall_verdict` |
@@ -164,6 +164,27 @@ event-specific fields.
 > name under `stress_event` rather than `event`, because `event` is already
 > the sink's envelope key. Do not assume `stress_progress` records reuse
 > `event` for the sub-event name.
+
+> **Heartbeat counters added:** `dropped_frames` counts frames shed because
+> the receive queue was saturated, and `checksum_mismatches` counts frames
+> whose trailing XOR byte did not match the payload. Both are cumulative for
+> the process. A non-zero `dropped_frames` means the run's own tooling could
+> not keep up and the latency/drop figures understate device performance.
+> Treat `checksum_mismatches` as diagnostic only for now — see §8.
+
+### 6.1 Scenario failures no longer abort a stress run
+
+A stress scenario that raises is recorded as a normal `ScenarioResult` with
+`verdict` `"FAIL"` and a single entry in `failure_reasons` of the form
+`scenario raised <ExceptionType>: <message>`; the run then continues with the
+remaining scenarios and still writes its report. Previously the exception
+propagated out of the run, so **no** report was written and the results of
+every scenario that had already completed were lost — the process just exited
+non-zero.
+
+Callers should therefore expect `failure_reasons` strings that describe a
+harness-side error rather than a threshold breach. The distinguishing marker
+is the `scenario raised ` prefix.
 
 ## 7. Result file envelope format
 
@@ -205,6 +226,17 @@ guarantee.
   this as a prerequisite if regression-mode automation is required.
 - **Exit code carries no verdict information** (§4) — always parse the
   summary/result JSON.
+- **Received frames are not checksum-verified by default.** `SerialInterface`
+  takes a `verify_checksum` flag that drops frames whose trailing XOR byte
+  does not match; it defaults to `False` because the firmware's reply format
+  is not settled in this repo — `command_mode.py` logs a received-vs-computed
+  checksum pair as though replies carry one, while `regression_test.py`
+  compares the decoded echo against the bare payload as though they do not.
+  Until that is confirmed against hardware, a corrupted frame that survives
+  COBS decoding is still counted as a valid echo. The `checksum_mismatches`
+  heartbeat counter (§6) reports how often this happens: a rate near zero
+  means replies are checksummed and the flag can be switched on; a rate near
+  100% means they are not, and the check should stay off.
 
 ## 9. Keeping this document in sync
 

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -368,10 +368,51 @@ class BaseTest:
         payload = header + bytes([0x01]) + index.to_bytes(1, byteorder="big")
         self.ser.write(payload)
 
+    def _send_status_requests(self, *, include_tasks: bool) -> None:
+        """
+        Send one request per status item, paced to avoid flooding the device.
+
+        The gap is only needed *between* requests, so the last one in the batch
+        is not followed by a sleep.
+        """
+        requests: list[tuple[bytes, int]] = [
+            (STATISTICS_HEADER_BYTES, index) for index in STATISTICS_ITEMS
+        ]
+        if include_tasks:
+            requests += [(TASK_HEADER_BYTES, index) for index in TASK_ITEMS]
+
+        last = len(requests) - 1
+        for position, (header, index) in enumerate(requests):
+            self._status_update(header, index)
+            if position != last:
+                time.sleep(STATUS_REQUEST_SPACING_S)
+
+    def _count_fresh(self, *, marker: float, include_tasks: bool) -> tuple[int, int]:
+        """Return how many statistics/task slots were updated after ``marker``."""
+        with self._status_lock:
+            stats_received = sum(
+                1
+                for idx in STATISTICS_ITEMS
+                if self._statistics_updated_at[idx] >= marker
+            )
+            tasks_received = (
+                sum(1 for idx in TASK_ITEMS if self._task_updated_at[idx] >= marker)
+                if include_tasks
+                else 0
+            )
+        return stats_received, tasks_received
+
     def _request_status_snapshot(
-        self, timeout_s: float = STATUS_REQUEST_TIMEOUT_S
+        self, timeout_s: float = STATUS_REQUEST_TIMEOUT_S, *, include_tasks: bool = True
     ) -> dict[str, Any]:
-        """Request device status snapshot and wait for responses."""
+        """
+        Request device status snapshot and wait for responses.
+
+        ``include_tasks=False`` polls only the statistics counters, skipping the
+        per-task requests. Callers that consume just ``status_delta`` (such as
+        the fault-injection scenario) save the pacing cost of those extra
+        round-trips on every snapshot.
+        """
         if self.ser is None:
             return {
                 "statistics": {},
@@ -381,28 +422,17 @@ class BaseTest:
             }
 
         snapshot_marker = time.perf_counter()
-        for index in STATISTICS_ITEMS:
-            self._status_update(STATISTICS_HEADER_BYTES, index)
-            time.sleep(STATUS_REQUEST_SPACING_S)
-        for index in TASK_ITEMS:
-            self._status_update(TASK_HEADER_BYTES, index)
-            time.sleep(STATUS_REQUEST_SPACING_S)
+        self._send_status_requests(include_tasks=include_tasks)
 
+        expected_tasks = len(TASK_ITEMS) if include_tasks else 0
         deadline = time.perf_counter() + timeout_s
         while time.perf_counter() < deadline:
-            with self._status_lock:
-                stats_received = sum(
-                    1
-                    for idx in STATISTICS_ITEMS
-                    if self._statistics_updated_at[idx] >= snapshot_marker
-                )
-                tasks_received = sum(
-                    1
-                    for idx in TASK_ITEMS
-                    if self._task_updated_at[idx] >= snapshot_marker
-                )
-            if stats_received == len(STATISTICS_ITEMS) and tasks_received == len(
-                TASK_ITEMS
+            stats_received, tasks_received = self._count_fresh(
+                marker=snapshot_marker, include_tasks=include_tasks
+            )
+            if (
+                stats_received == len(STATISTICS_ITEMS)
+                and tasks_received == expected_tasks
             ):
                 break
             time.sleep(0.01)
@@ -412,16 +442,15 @@ class BaseTest:
                 name: self._statistics_values[idx]
                 for idx, name in STATISTICS_ITEMS.items()
             }
-            tasks = {name: self._task_values[idx] for idx, name in TASK_ITEMS.items()}
+            tasks = (
+                {name: self._task_values[idx] for idx, name in TASK_ITEMS.items()}
+                if include_tasks
+                else {}
+            )
             min_free_heap_bytes = self._min_free_heap_bytes
-            stats_received = sum(
-                1
-                for idx in STATISTICS_ITEMS
-                if self._statistics_updated_at[idx] >= snapshot_marker
-            )
-            tasks_received = sum(
-                1 for idx in TASK_ITEMS if self._task_updated_at[idx] >= snapshot_marker
-            )
+        stats_received, tasks_received = self._count_fresh(
+            marker=snapshot_marker, include_tasks=include_tasks
+        )
         return {
             "statistics": statistics,
             "tasks": tasks,
@@ -429,7 +458,7 @@ class BaseTest:
             "received": {"statistics": stats_received, "tasks": tasks_received},
             "complete": (
                 stats_received == len(STATISTICS_ITEMS)
-                and tasks_received == len(TASK_ITEMS)
+                and tasks_received == expected_tasks
             ),
         }
 

--- a/src/base_test.py
+++ b/src/base_test.py
@@ -43,6 +43,9 @@ TASK_HEADER_BYTES = bytes([0x00, 0x38])
 STATUS_REQUEST_SPACING_S = 0.02
 STATUS_REQUEST_TIMEOUT_S = 2.0
 
+# Accepted affirmative answers for boolean prompts; anything else reads as false.
+TRUE_INPUTS = frozenset({"true", "t", "yes", "y", "1"})
+
 STATISTICS_ITEMS = {
     0: "queue_send_error",
     1: "queue_receive_error",
@@ -186,6 +189,11 @@ class BaseTest:
         self._run_id: str = uuid.uuid4().hex[:8]
         self.latency_msg_sent: dict[int, float] = {}
         self.latency_msg_received: dict[int, float] = {}
+        # Guards the two latency dicts: publish() writes from the main thread
+        # while handle_message() writes from the processing thread, and result
+        # collection iterates them.  Use _latency_snapshot()/_reset_latency()
+        # instead of touching the dicts directly.
+        self._latency_lock = threading.Lock()
         self._status_lock = threading.Lock()
         self._statistics_values: dict[int, int] = dict.fromkeys(STATISTICS_ITEMS, 0)
         self._statistics_updated_at: dict[int, float] = dict.fromkeys(
@@ -207,10 +215,31 @@ class BaseTest:
         m_length = (len(trailer) + 2).to_bytes(1, byteorder="big")
         payload = HEADER_BYTES + m_length + counter + trailer
 
-        self.latency_msg_sent[iteration_counter] = time.perf_counter()
+        with self._latency_lock:
+            self.latency_msg_sent[iteration_counter] = time.perf_counter()
         self.ser.write(payload)
         self.ser.flush()
         logger.info("Published (encoded) `%s`, counter %s", payload, iteration_counter)
+
+    def _reset_latency(self) -> None:
+        """Clear both latency dictionaries atomically."""
+        with self._latency_lock:
+            self.latency_msg_sent.clear()
+            self.latency_msg_received.clear()
+
+    def _latency_snapshot(self) -> tuple[list[float], int, int]:
+        """
+        Return ``(latencies, sent_count, received_count)`` consistently.
+
+        Copies under the lock so a late echo arriving on the processing thread
+        cannot resize the dict mid-iteration.
+        """
+        with self._latency_lock:
+            return (
+                list(self.latency_msg_received.values()),
+                len(self.latency_msg_sent),
+                len(self.latency_msg_received),
+            )
 
     def handle_message(self, command: int, decoded_data: bytes) -> None:
         """Handle return message and store measured latency."""
@@ -218,8 +247,9 @@ class BaseTest:
             try:
                 counter_bytes = [decoded_data[3], decoded_data[4]]
                 counter = int.from_bytes(counter_bytes, byteorder="big")
-                latency = time.perf_counter() - self.latency_msg_sent[counter]
-                self.latency_msg_received[counter] = latency
+                with self._latency_lock:
+                    latency = time.perf_counter() - self.latency_msg_sent[counter]
+                    self.latency_msg_received[counter] = latency
                 logger.info("Message %d latency: %.5f ms", counter, latency * 1e3)
             except IndexError:
                 logger.info("Invalid message (Index Error)")
@@ -273,10 +303,11 @@ class BaseTest:
         jitter: bool = False,
     ) -> dict[str, Any]:
         """Calculate latency statistics and dropped messages."""
-        dropped_messages = len(self.latency_msg_sent) - len(self.latency_msg_received)
+        latencies, sent_count, received_count = self._latency_snapshot()
+        dropped_messages = sent_count - received_count
         logger.info("Dropped messages: %d ", dropped_messages)
 
-        if not self.latency_msg_received:
+        if not latencies:
             logger.info("No results collected for this test.")
             return {
                 "test": test,
@@ -291,7 +322,6 @@ class BaseTest:
                 "dropped_messages": dropped_messages,
             }
 
-        latencies = list(self.latency_msg_received.values())
         latency_avg = sum(latencies) / len(latencies)
         latency_min = min(latencies)
         latency_max = max(latencies)
@@ -426,12 +456,31 @@ class BaseTest:
         return {"statistics": statistics_delta, "tasks": tasks_delta}
 
     def _get_user_input(self, prompt: str, default_value: Any) -> Any:
-        """Get user input with default fallback."""
+        """
+        Get user input with default fallback.
+
+        Booleans are parsed by word rather than cast, because ``bool("False")``
+        is ``True`` -- a plain cast makes it impossible to answer "no". A value
+        that cannot be converted falls back to the default instead of raising.
+        """
         user_input = console.input(
             f"[bold]{prompt}[/bold] [dim](default: {default_value})[/dim]: "
         )
-        return (
-            default_value
-            if user_input.strip() == ""
-            else type(default_value)(user_input)
-        )
+        text = user_input.strip()
+        if text == "":
+            return default_value
+
+        # bool is a subclass of int, so it has to be handled before the cast.
+        if isinstance(default_value, bool):
+            return text.lower() in TRUE_INPUTS
+
+        try:
+            return type(default_value)(text)
+        except (TypeError, ValueError):
+            logger.info(
+                "Invalid value %r for '%s'. Using default %r.",
+                text,
+                prompt,
+                default_value,
+            )
+            return default_value

--- a/src/baud_rate_test.py
+++ b/src/baud_rate_test.py
@@ -72,8 +72,7 @@ class BaudRateTest(BaseTest):
 
         with alive_bar(samples * len(baud_rates), title=bar_title) as pbar:
             for j, rate in enumerate(baud_rates):
-                self.latency_msg_sent.clear()
-                self.latency_msg_received.clear()
+                self._reset_latency()
                 outstanding_messages: list[int] = []
                 status_before = self._request_status_snapshot()
 
@@ -98,17 +97,15 @@ class BaudRateTest(BaseTest):
                     self.publish(i, length)
                     time.sleep(min_uart_delay)
                     pbar()
-                    outstanding_messages.append(
-                        len(self.latency_msg_sent) - len(self.latency_msg_received)
-                    )
+                    _, sent_count, received_count = self._latency_snapshot()
+                    outstanding_messages.append(sent_count - received_count)
 
                 burst_elapsed_time = time.perf_counter() - burst_init_time
                 logger.info("Waiting for %d seconds to collect results...", wait_time)
                 time.sleep(wait_time)
                 status_after = self._request_status_snapshot()
-                outstanding_final = len(self.latency_msg_sent) - len(
-                    self.latency_msg_received
-                )
+                latency_results, sent_count, received_count = self._latency_snapshot()
+                outstanding_final = sent_count - received_count
 
                 bitrate = (samples * 8 * length) / burst_elapsed_time
 
@@ -119,7 +116,6 @@ class BaudRateTest(BaseTest):
                     bitrate=bitrate,
                 )
                 test_results["baudrate"] = rate
-                latency_results = list(self.latency_msg_received.values())
                 output_data.append(
                     {
                         **test_results,

--- a/src/command_mode.py
+++ b/src/command_mode.py
@@ -32,6 +32,14 @@ setup_logging()
 
 logger = logging.getLogger(__name__)
 
+# Minimum decoded lengths before the corresponding fields can be indexed.
+_HEADER_LEN = 3  # rxID_high, rxID_low|cmd, len_field
+_KEY_FRAME_LEN = 4  # header + packed col/row/state byte
+_ANALOG_FRAME_LEN = 6  # header + channel + 2 value bytes
+
+# Bound on undisplayed frames, so a stalled display cannot grow without limit.
+MAX_QUEUE_SIZE = 10000
+
 
 class CommandMode:
     """
@@ -52,7 +60,7 @@ class CommandMode:
 
         """
         self.serial_interface = serial_interface
-        self.message_queue = queue.Queue()
+        self.message_queue = queue.Queue(maxsize=MAX_QUEUE_SIZE)
         self.running = False
         self.input_lock = threading.Lock()
         self.current_input = ""
@@ -125,9 +133,12 @@ class CommandMode:
         while self.running:
             try:
                 message = self.message_queue.get(timeout=0.1)
-                self._handle_message(*message)
             except queue.Empty:
                 continue
+            try:
+                self._handle_message(*message)
+            except Exception:  # A bad frame must not kill the display thread
+                logger.exception("Error displaying received message")
 
     def handle_message(
         self,
@@ -145,8 +156,12 @@ class CommandMode:
         byte_string (bytes): The raw byte string received.
 
         """
-        # Add message to queue for processing
-        self.message_queue.put((command, decoded_data, byte_string))
+        # Add message to queue for processing.  Called from the serial
+        # processing thread, so never block it on a saturated queue.
+        try:
+            self.message_queue.put_nowait((command, decoded_data, byte_string))
+        except queue.Full:
+            logger.warning("Command mode queue full; dropping frame for display")
 
     def _handle_message(
         self,
@@ -165,16 +180,21 @@ class CommandMode:
                 sys.stdout.flush()
 
                 # Print the message
-                cobs_decoded = cobs.decode(byte_string)
+                try:
+                    cobs_decoded = cobs.decode(byte_string)
+                except cobs.DecodeError:
+                    logger.warning("Undecodable frame: %s", byte_string.hex())
+                    cobs_decoded = b""
                 received_checksum = cobs_decoded[-1:]
                 calculated_checksum = calculate_checksum(cobs_decoded[:-1])
                 logger.info(
-                    "Received raw: %s, decoded: %s, \
-                        Received Checksum: %s, Calculated Checksum: %s",
+                    "Received raw: %s, decoded: %s, Received Checksum: %s, "
+                    "Calculated Checksum: %s, Match: %s",
                     byte_string,
                     decoded_data,
                     received_checksum,
                     calculated_checksum,
+                    received_checksum == calculated_checksum,
                 )
                 self._print_decoded_message(decoded_data)
 
@@ -193,11 +213,17 @@ class CommandMode:
         """
         logout = " ".join(f"{i}: {msg}" for i, msg in enumerate(message))
         logger.info("Decoded message: %s", logout)
+        if len(message) < _HEADER_LEN:
+            logger.warning("Frame too short to decode header (%d bytes)", len(message))
+            return
         rxid = (message[0] << 3) | ((message[1] & 0xE0) >> 5)
         command = message[1] & 0x1F
         length = message[2]
         logger.info("Id: %s, Command: %s", rxid, command)
         if command == SerialCommand.KEY_COMMAND.value:
+            if len(message) < _KEY_FRAME_LEN:
+                logger.warning("Key frame truncated (%d bytes)", len(message))
+                return
             state = message[3] & 0x01
             col = (message[3] >> 4) & 0x0F
             row = (message[3] >> 1) & 0x0F
@@ -209,6 +235,9 @@ class CommandMode:
                 length,
             )
         elif command == SerialCommand.ANALOG_COMMAND.value:
+            if len(message) < _ANALOG_FRAME_LEN:
+                logger.warning("Analog frame truncated (%d bytes)", len(message))
+                return
             channel = message[3]
             value = (message[4] << 8) | message[5]
             logger.info("Channel: %s, Value: %s", channel, value)

--- a/src/latency_test.py
+++ b/src/latency_test.py
@@ -67,6 +67,7 @@ class LatencyTest(BaseTest):
         jitter: bool = False,
     ) -> None:
         """Execute the main test given the desired parameters."""
+        num_times, samples = self._validate_run_size(num_times, samples)
         output_filename = make_result_filename("latency", self._run_id)
         file_path = Path(__file__).parent.parent / TEST_RESULTS_FOLDER / output_filename
 
@@ -87,11 +88,13 @@ class LatencyTest(BaseTest):
 
         with alive_bar(samples * num_times, title=bar_title) as pbar:
             for j in range(num_times):
-                self.latency_msg_sent.clear()
-                self.latency_msg_received.clear()
+                self._reset_latency()
                 outstanding_messages: list[int] = []
                 status_before = self._request_status_snapshot()
-                raw_wait = min_wait + (max_wait - min_wait) * (j / (num_times - 1))
+                # With a single iteration the ramp degenerates to one point;
+                # dividing by num_times - 1 would be a division by zero.
+                ramp = j / (num_times - 1) if num_times > 1 else 0.0
+                raw_wait = min_wait + (max_wait - min_wait) * ramp
                 waiting_time = max(raw_wait, min_uart_delay)
                 logger.info("Test %s, waiting time: %d s", j, waiting_time)
                 random_max = (max_wait - min_wait) * 0.2
@@ -106,17 +109,15 @@ class LatencyTest(BaseTest):
                     else:
                         time.sleep(waiting_time)
                     pbar()
-                    outstanding_messages.append(
-                        len(self.latency_msg_sent) - len(self.latency_msg_received)
-                    )
+                    _, sent_count, received_count = self._latency_snapshot()
+                    outstanding_messages.append(sent_count - received_count)
 
                 burst_elapsed_time = time.perf_counter() - burst_init_time
                 logger.info("Waiting for %d seconds to collect results...", wait_time)
                 time.sleep(wait_time)
                 status_after = self._request_status_snapshot()
-                outstanding_final = len(self.latency_msg_sent) - len(
-                    self.latency_msg_received
-                )
+                latencies, sent_count, received_count = self._latency_snapshot()
+                outstanding_final = sent_count - received_count
                 # Calculated bitrate considering the total payload (HEADER_BYTES + 1)
                 bitrate = (samples * 8 * length) / burst_elapsed_time
 
@@ -127,7 +128,7 @@ class LatencyTest(BaseTest):
                     bitrate=bitrate,
                     jitter=jitter,
                 )
-                latency_results_copy[j] = list(self.latency_msg_received.values())
+                latency_results_copy[j] = latencies
                 output_data.append(
                     {
                         **test_results,
@@ -146,6 +147,33 @@ class LatencyTest(BaseTest):
                 )
 
         self._write_output_to_file(file_path, output_data)
+
+    @staticmethod
+    def _validate_run_size(num_times: int, samples: int) -> tuple[int, int]:
+        """
+        Clamp iteration and sample counts to values the protocol can express.
+
+        Applied inside ``main_test`` rather than only in ``_show_options`` so
+        the headless entry points (``execute_test_with_options`` and
+        ``runner_cli``) get the same guarantees.  The sample ceiling matters
+        because ``publish()`` packs the counter into two bytes.
+        """
+        if num_times <= 0:
+            logger.info(
+                "Invalid number of times (%d). Using default value %d.",
+                num_times,
+                DEFAULT_NUM_TIMES,
+            )
+            num_times = DEFAULT_NUM_TIMES
+        if samples <= 0 or samples >= MAX_SAMPLE_SIZE:
+            logger.info(
+                "Invalid number of samples (%d); must be in 1..%d. Using default %d.",
+                samples,
+                MAX_SAMPLE_SIZE - 1,
+                DEFAULT_SAMPLES,
+            )
+            samples = DEFAULT_SAMPLES
+        return num_times, samples
 
     def _default_min_wait_ms(
         self, message_length: int = DEFAULT_MESSAGE_LENGTH
@@ -199,7 +227,7 @@ class LatencyTest(BaseTest):
         num_samples = self._get_user_input(
             "(5/7) Enter number of samples", DEFAULT_SAMPLES
         )
-        if num_samples <= 0 and num_samples < MAX_SAMPLE_SIZE:
+        if num_samples <= 0 or num_samples >= MAX_SAMPLE_SIZE:
             num_samples = DEFAULT_SAMPLES
             logger.info("Invalid number of samples. Using default value.")
 

--- a/src/logger_config.py
+++ b/src/logger_config.py
@@ -32,12 +32,15 @@ class _Dispatch:
 
     listener: logging.handlers.QueueListener | None = None
     atexit_registered: bool = False
+    configured: bool = False
 
 
 def setup_logging(
     default_path: str = "logging_config.ini",
     default_level: int = logging.INFO,
     env_key: str = "LOG_CFG",
+    *,
+    force: bool = False,
 ) -> None:
     """
     Configure logging with a non-blocking, queue-based dispatcher.
@@ -45,7 +48,15 @@ def setup_logging(
     Loggers receive a single `QueueHandler` that enqueues records and returns
     immediately; a background `QueueListener` thread owns the real I/O
     handlers so stdout/file writes never block producer threads.
+
+    Configuration happens once per process. Eight modules call this at import
+    time, and every call re-reads the ini file, re-opens the log handlers, and
+    tears down and restarts the listener thread -- so repeat calls are ignored
+    unless ``force=True``.
     """
+    if _Dispatch.configured and not force:
+        return
+
     path: Path = Path(__file__).parent.parent / default_path
     value = os.getenv(env_key, None)
     if value:
@@ -58,6 +69,7 @@ def setup_logging(
 
     _install_queue_dispatch()
     _rebind_stdout_handlers()
+    _Dispatch.configured = True
 
 
 class _LateBoundStdout:

--- a/src/regression_test.py
+++ b/src/regression_test.py
@@ -24,6 +24,9 @@ setup_logging()
 
 logger = logging.getLogger(__name__)
 
+# Payload sent by test_echo_command and expected back verbatim from the device.
+ECHO_PAYLOAD = bytes([0x00, 0x34, 0x02, 0x01, 0x02])
+
 
 class RegressionTest:
     """Regression test class."""
@@ -42,15 +45,16 @@ class RegressionTest:
         """Handle message for regression test."""
         if command == SerialCommand.ECHO_COMMAND.value:
             try:
-                if decoded_data == bytes([0x00, 0x34, 0x02, 0x01, 0x02]):
+                # decoded_data is the full frame: payload + trailing XOR
+                # checksum. SerialInterface has already verified that byte, so
+                # compare only the payload against what test_echo_command sent.
+                echoed_payload = decoded_data[: len(ECHO_PAYLOAD)]
+                if echoed_payload == ECHO_PAYLOAD:
                     logger.info("[OK] Echo command")
                 else:
                     logger.info("[FAIL] Echo command")
 
-                logger.info(
-                    "Expected: %s",
-                    bytes([0x00, 0x34, 0x02, 0x01, 0x02]),
-                )
+                logger.info("Expected: %s", ECHO_PAYLOAD)
                 logger.info(
                     "Received: %s, command: %s, decoded: %s",
                     byte_string,
@@ -64,8 +68,7 @@ class RegressionTest:
 
     def test_echo_command(self) -> None:
         """Test echo command."""
-        payload = bytes([0x00, 0x34, 0x02, 0x01, 0x02])
-        self.ser.write(payload)
+        self.ser.write(ECHO_PAYLOAD)
 
     def execute_test(self) -> None:
         """Execute regression test."""

--- a/src/runner_cli.py
+++ b/src/runner_cli.py
@@ -308,6 +308,8 @@ def _load_stress_cfg(path: str) -> StressConfig:
 def _extract_tester_counters(tester: Any) -> dict[str, Any]:
     """Return generic counters from tester objects for heartbeat events."""
     counters: dict[str, Any] = {}
+    # len() on a dict reads its size directly rather than iterating, so it is
+    # safe to call while the processing thread inserts entries.
     sent = getattr(tester, "latency_msg_sent", None)
     received = getattr(tester, "latency_msg_received", None)
     if isinstance(sent, dict):
@@ -326,15 +328,19 @@ def _run_feedback_loop(
     """Emit periodic heartbeat events while a run is active."""
     while not monitor.stop_event.wait(monitor.interval_s):
         tester = monitor.tester_getter()
-        serial_stats = monitor.serial.statistics
+        # Snapshot under the statistics lock: these counters are mutated by the
+        # read and processing threads while this heartbeat thread reads them.
+        serial_stats = monitor.serial.statistics.snapshot()
         monitor.sink.emit(
             "heartbeat",
             mode=monitor.mode,
             elapsed_s=round(time.time() - monitor.start_time, 3),
-            bytes_sent=serial_stats.bytes_sent,
-            bytes_received=serial_stats.bytes_received,
-            commands_sent=dict(serial_stats.commands_sent),
-            commands_received=dict(serial_stats.commands_received),
+            bytes_sent=serial_stats["bytes_sent"],
+            bytes_received=serial_stats["bytes_received"],
+            commands_sent=serial_stats["commands_sent"],
+            commands_received=serial_stats["commands_received"],
+            dropped_frames=serial_stats["dropped_frames"],
+            checksum_mismatches=serial_stats["checksum_mismatches"],
             **(_extract_tester_counters(tester) if tester is not None else {}),
         )
 

--- a/src/serial_interface.py
+++ b/src/serial_interface.py
@@ -22,7 +22,7 @@ import queue
 import threading
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import serial
 from cobs import cobs
@@ -49,14 +49,70 @@ class SerialCommand(Enum):
 
 
 class SerialStatistics:
-    """Serial interface statistics."""
+    """
+    Serial interface statistics.
+
+    Counters are written by the read thread (``bytes_received``) and the
+    processing thread (``commands_received``) while being read by the main
+    thread and, under the headless runner, by the heartbeat thread.  Every
+    mutation and every read therefore goes through ``_lock``; consumers should
+    call :meth:`snapshot` rather than iterating the dictionaries directly.
+    """
 
     def __init__(self) -> None:
         """Initialize statistics."""
+        self._lock = threading.Lock()
         self.bytes_received = 0
         self.bytes_sent = 0
         self.commands_sent: dict[int, int] = defaultdict(int)
         self.commands_received: dict[int, int] = defaultdict(int)
+        # Frames dropped because the processing queue was saturated.
+        self.dropped_frames = 0
+        # Frames whose trailing XOR checksum did not match the payload.
+        self.checksum_mismatches = 0
+
+    def record_sent(self, command: int, byte_count: int) -> None:
+        """Account for one transmitted frame."""
+        with self._lock:
+            self.bytes_sent += byte_count
+            self.commands_sent[command] += 1
+
+    def record_sent_bytes(self, byte_count: int) -> None:
+        """Account for raw bytes written outside the framed command path."""
+        with self._lock:
+            self.bytes_sent += byte_count
+
+    def record_received_bytes(self, byte_count: int) -> None:
+        """Account for raw bytes read from the port."""
+        with self._lock:
+            self.bytes_received += byte_count
+
+    def record_received_command(self, command: int) -> None:
+        """Account for one successfully decoded frame."""
+        with self._lock:
+            self.commands_received[command] += 1
+
+    def record_dropped_frame(self) -> None:
+        """Account for one frame discarded because the queue was full."""
+        with self._lock:
+            self.dropped_frames += 1
+
+    def record_checksum_mismatch(self) -> None:
+        """Account for one frame whose trailing checksum did not verify."""
+        with self._lock:
+            self.checksum_mismatches += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a consistent, plain-dict copy of every counter."""
+        with self._lock:
+            return {
+                "bytes_received": self.bytes_received,
+                "bytes_sent": self.bytes_sent,
+                "commands_sent": dict(self.commands_sent),
+                "commands_received": dict(self.commands_received),
+                "dropped_frames": self.dropped_frames,
+                "checksum_mismatches": self.checksum_mismatches,
+            }
 
 
 class SerialInterface:
@@ -65,22 +121,50 @@ class SerialInterface:
     BUFFER_HIGH_WATER = 768  # 75% of max buffer size
     BUFFER_LOW_WATER = 256  # 25% of max buffer size
     MAX_BUFFER_SIZE = 1024
+    # Upper bound on undelivered frames.  Keeps a stalled or dead consumer from
+    # growing the queue without limit while the device floods the port.
+    MAX_QUEUE_SIZE = 10000
+    # Longest a shutdown will wait on a worker thread before giving up, so a
+    # wedged read thread cannot hang a headless run forever.
+    JOIN_TIMEOUT_S = 5.0
 
-    def __init__(self, port: str, baudrate: int, timeout: float) -> None:
-        """Initialize the serial interface."""
+    def __init__(
+        self,
+        port: str,
+        baudrate: int,
+        timeout: float,
+        *,
+        verify_checksum: bool = False,
+    ) -> None:
+        """
+        Initialize the serial interface.
+
+        ``verify_checksum`` makes :meth:`_process_complete_message` drop frames
+        whose trailing XOR byte does not match the payload.  It defaults to
+        ``False`` because it is not settled whether the firmware appends a
+        checksum to its *replies*: ``command_mode`` logs a received-vs-computed
+        pair as if it does, while ``regression_test`` compares the decoded echo
+        against the bare payload as if it does not.  Mismatches are counted in
+        ``statistics.checksum_mismatches`` regardless, so a run against real
+        hardware settles the question before the drop is switched on.
+        """
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
+        self.verify_checksum = verify_checksum
         self.ser = None
         self.stop_event = threading.Event()
         self.message_handler: Callable[[int, bytes, bytes], None] | None = None
-        self.message_queue = queue.Queue()
+        self.message_queue = queue.Queue(maxsize=self.MAX_QUEUE_SIZE)
         self.read_thread = threading.Thread(target=self._read_data)
         self.processing_thread = threading.Thread(target=self._process_messages)
         self.read_thread.daemon = True
         self.processing_thread.daemon = True
         self.buffer = bytearray()
         self.statistics: SerialStatistics = SerialStatistics()
+        # Serializes access to the port so concurrent producers (echo publisher,
+        # status pollers, raw fault injection) cannot interleave bytes mid-frame.
+        self._write_lock = threading.Lock()
 
     def open(self) -> bool:
         """Open serial port."""
@@ -107,15 +191,22 @@ class SerialInterface:
             return True
 
     def close(self) -> None:
-        """Close serial port."""
+        """Close serial port, waiting a bounded time for the worker threads."""
         self.stop_event.set()
 
-        # Only attempt to join if we're not in the read thread
+        # Never join the thread we are running on, and skip threads that were
+        # never started -- Thread.join() raises RuntimeError on those.
         current_thread = threading.current_thread()
-        if self.read_thread and current_thread != self.read_thread:
-            self.read_thread.join()
-        if self.processing_thread and current_thread != self.processing_thread:
-            self.processing_thread.join()
+        for thread in (self.read_thread, self.processing_thread):
+            if thread is None or thread is current_thread or not thread.is_alive():
+                continue
+            thread.join(timeout=self.JOIN_TIMEOUT_S)
+            if thread.is_alive():
+                logger.warning(
+                    "Thread %s did not stop within %.1fs; abandoning it",
+                    thread.name,
+                    self.JOIN_TIMEOUT_S,
+                )
 
         if self.ser:
             self.ser.close()
@@ -149,15 +240,44 @@ class SerialInterface:
                     checksum = calculate_checksum(data)
                     payload_with_checksum = data + checksum
                     message = cobs.encode(payload_with_checksum) + b"\x00"
-                    bytes_writen = self.ser.write(message) or 0
-                    self.statistics.bytes_sent += bytes_writen
                     command: int = data[1] & 0x1F
-                    self.statistics.commands_sent[command] += 1
+                    with self._write_lock:
+                        bytes_writen = self.ser.write(message) or 0
+                    self.statistics.record_sent(command, bytes_writen)
                     logger.info("Published (encoded) `%s`", message)
             else:
                 logger.info("Serial port not open")
         except IndexError:
             logger.exception("Error processing message to send")
+        except serial.SerialTimeoutException:
+            # write_timeout is 0 (non-blocking), so a saturated output buffer
+            # surfaces here.  Drop the frame rather than abort the caller's run.
+            logger.warning("Write timed out; output buffer full, frame dropped")
+        except serial.SerialException:
+            logger.exception("Serial error while writing; frame dropped")
+
+    def write_raw(self, data: bytes) -> None:
+        """
+        Write bytes verbatim, bypassing COBS framing and the checksum.
+
+        Used by fault-injection and noise scenarios that must put malformed
+        sequences on the wire.  Takes the same lock as :meth:`write` so raw
+        injection cannot interleave with framed traffic.
+        """
+        if not self.ser:
+            logger.info("Serial port not open")
+            return
+        try:
+            with self._write_lock:
+                bytes_written = self.ser.write(data) or 0
+                self.ser.flush()
+            # Raw frames carry no command id, so only the byte counter moves.
+            self.statistics.record_sent_bytes(bytes_written)
+            logger.info("Wrote %d raw bytes", bytes_written)
+        except serial.SerialTimeoutException:
+            logger.warning("Raw write timed out; output buffer full")
+        except serial.SerialException:
+            logger.exception("Serial error while writing raw bytes")
 
     def flush(self) -> None:
         """Flush the serial output buffer, blocking until all data is transmitted."""
@@ -198,16 +318,45 @@ class SerialInterface:
         try:
             decoded_data: bytes = cobs.decode(byte_string)
             command: int = decoded_data[1] & 0x1F
+            if not self._checksum_ok(decoded_data):
+                self.statistics.record_checksum_mismatch()
+                logger.warning(
+                    "Checksum mismatch on frame `%s`%s",
+                    byte_string.hex(),
+                    " (dropped)" if self.verify_checksum else " (accepted)",
+                )
+                if self.verify_checksum:
+                    return
             # Add a counter of commands
-            self.statistics.commands_received[command] += 1
+            self.statistics.record_received_command(command)
             if self.message_handler:
                 self.message_handler(command, decoded_data, byte_string)
         except (IndexError, cobs.DecodeError):  # fmt: skip
             logger.exception("Error processing message")
 
+    @staticmethod
+    def _checksum_ok(decoded_data: bytes) -> bool:
+        """Return whether the trailing XOR byte matches the preceding payload."""
+        if len(decoded_data) < 2:  # noqa: PLR2004  # payload + checksum minimum
+            return False
+        return calculate_checksum(decoded_data[:-1]) == decoded_data[-1:]
+
+    def _enqueue_message(self, frame: bytes) -> None:
+        """Queue a complete frame, dropping it if the consumer is saturated."""
+        try:
+            self.message_queue.put_nowait(frame)
+        except queue.Full:
+            # Never block the read thread on a stalled consumer: shed the frame
+            # and keep draining the port.
+            self.statistics.record_dropped_frame()
+            logger.warning(
+                "Message queue full (%d frames); dropping frame",
+                self.MAX_QUEUE_SIZE,
+            )
+
     def _handle_received_data(self, data: bytes, max_message_size: int) -> None:
         """Handle received data and put complete messages in the queue."""
-        self.statistics.bytes_received += len(data)
+        self.statistics.record_received_bytes(len(data))
 
         # Update RTS based on buffer size
         if self.ser:
@@ -219,7 +368,7 @@ class SerialInterface:
         for byte in data:
             if byte == 0:  # COBS packet delimiter
                 if self.buffer:  # Only process if we have a complete packet
-                    self.message_queue.put(bytes(self.buffer))
+                    self._enqueue_message(bytes(self.buffer))
                     self.buffer.clear()  # Clear buffer only after processing
             else:
                 self.buffer.append(byte)

--- a/src/serial_interface.py
+++ b/src/serial_interface.py
@@ -124,6 +124,10 @@ class SerialInterface:
     # Upper bound on undelivered frames.  Keeps a stalled or dead consumer from
     # growing the queue without limit while the device floods the port.
     MAX_QUEUE_SIZE = 10000
+    # RTS watermarks, as a fraction of MAX_QUEUE_SIZE.  Hysteresis between the
+    # two keeps the line from flapping around a single threshold.
+    QUEUE_HIGH_WATER = int(MAX_QUEUE_SIZE * 0.75)
+    QUEUE_LOW_WATER = int(MAX_QUEUE_SIZE * 0.25)
     # Longest a shutdown will wait on a worker thread before giving up, so a
     # wedged read thread cannot hang a headless run forever.
     JOIN_TIMEOUT_S = 5.0
@@ -134,19 +138,20 @@ class SerialInterface:
         baudrate: int,
         timeout: float,
         *,
-        verify_checksum: bool = False,
+        verify_checksum: bool = True,
     ) -> None:
         """
         Initialize the serial interface.
 
         ``verify_checksum`` makes :meth:`_process_complete_message` drop frames
-        whose trailing XOR byte does not match the payload.  It defaults to
-        ``False`` because it is not settled whether the firmware appends a
-        checksum to its *replies*: ``command_mode`` logs a received-vs-computed
-        pair as if it does, while ``regression_test`` compares the decoded echo
-        against the bare payload as if it does not.  Mismatches are counted in
-        ``statistics.checksum_mismatches`` regardless, so a run against real
-        hardware settles the question before the drop is switched on.
+        whose trailing XOR byte does not match the payload, so a corrupted frame
+        that survives COBS decoding is no longer counted as a valid reply.  The
+        wire format is symmetric — ``COBS_ENCODE(body + XOR_checksum) + 0x00`` in
+        both directions — so replies carry the checksum the same way commands do.
+
+        Pass ``verify_checksum=False`` to fall back to counting mismatches in
+        ``statistics.checksum_mismatches`` without dropping anything, which is
+        useful when bringing up firmware whose reply framing is still in flux.
         """
         self.port = port
         self.baudrate = baudrate
@@ -341,6 +346,24 @@ class SerialInterface:
             return False
         return calculate_checksum(decoded_data[:-1]) == decoded_data[-1:]
 
+    def _update_flow_control(self) -> None:
+        """
+        Assert or release RTS based on how far behind the consumer is.
+
+        Backpressure has to be measured on the queue of undelivered frames, not
+        on ``self.buffer``: that buffer only holds the frame currently being
+        assembled and is cleared at every delimiter, so for normal ~12-byte
+        frames it never approaches the watermark and RTS never engages. Queue
+        depth is what actually grows when the processing thread falls behind.
+        """
+        if not self.ser:
+            return
+        pending = self.message_queue.qsize()
+        if pending > self.QUEUE_HIGH_WATER:
+            self.ser.rts = False  # Stop sender
+        elif pending < self.QUEUE_LOW_WATER:
+            self.ser.rts = True  # Allow sender to send
+
     def _enqueue_message(self, frame: bytes) -> None:
         """Queue a complete frame, dropping it if the consumer is saturated."""
         try:
@@ -357,13 +380,7 @@ class SerialInterface:
     def _handle_received_data(self, data: bytes, max_message_size: int) -> None:
         """Handle received data and put complete messages in the queue."""
         self.statistics.record_received_bytes(len(data))
-
-        # Update RTS based on buffer size
-        if self.ser:
-            if len(self.buffer) > self.BUFFER_HIGH_WATER:
-                self.ser.rts = False  # Stop sender
-            elif len(self.buffer) < self.BUFFER_LOW_WATER:
-                self.ser.rts = True  # Allow sender to send
+        self._update_flow_control()
 
         for byte in data:
             if byte == 0:  # COBS packet delimiter

--- a/src/status_mode.py
+++ b/src/status_mode.py
@@ -178,6 +178,21 @@ class StatusMode:
         self.logger.info("Status request complete")
 
     @staticmethod
+    def _command_label(value: int) -> str:
+        """
+        Return a display name for a command id.
+
+        Counters are keyed by ``data[1] & 0x1F`` (0-31), but only five of those
+        are named in ``SerialCommand`` -- an arbitrary hex frame sent from
+        Command Mode, or an unexpected device reply, produces an id with no
+        enum member.  Render those instead of raising.
+        """
+        try:
+            return SerialCommand(value).name
+        except ValueError:
+            return f"UNKNOWN(0x{value:02X})"
+
+    @staticmethod
     def _fmt_timestamp(ts: float) -> str:
         """Format a Unix timestamp as a UTC datetime string, or 'N/A' if zero."""
         if ts == 0:
@@ -212,6 +227,10 @@ class StatusMode:
 
         console.print(stats_table)
 
+        # Copy the counters once: the read and processing threads keep mutating
+        # them, and iterating the live dicts can change size mid-loop.
+        stats = self.ser.statistics.snapshot()
+
         # --- Commands sent table ---
         sent_table = Table(
             title="Commands Sent",
@@ -220,12 +239,10 @@ class StatusMode:
         )
         sent_table.add_column("Command", style="bold")
         sent_table.add_column("Count", justify="right")
-        for k, v in self.ser.statistics.commands_sent.items():
-            sent_table.add_row(SerialCommand(k).name, f"{v:,}")
+        for k, v in stats["commands_sent"].items():
+            sent_table.add_row(self._command_label(k), f"{v:,}")
         console.print(sent_table)
-        console.print(
-            f"  Total bytes sent: [cyan]{self.ser.statistics.bytes_sent:,}[/cyan]"
-        )
+        console.print(f"  Total bytes sent: [cyan]{stats['bytes_sent']:,}[/cyan]")
 
         # --- Commands received table ---
         recv_table = Table(
@@ -235,10 +252,10 @@ class StatusMode:
         )
         recv_table.add_column("Command", style="bold")
         recv_table.add_column("Count", justify="right")
-        for k, v in self.ser.statistics.commands_received.items():
-            recv_table.add_row(SerialCommand(k).name, f"{v:,}")
+        for k, v in stats["commands_received"].items():
+            recv_table.add_row(self._command_label(k), f"{v:,}")
         console.print(recv_table)
-        received = self.ser.statistics.bytes_received
+        received = stats["bytes_received"]
         console.print(f"  Total bytes received: [cyan]{received:,}[/cyan]")
 
     def format_time_from_microseconds(self, microseconds: int) -> str:

--- a/src/status_mode.py
+++ b/src/status_mode.py
@@ -29,6 +29,7 @@ from base_test import (
     STATISTICS_DISPLAY_NAMES,
     STATISTICS_HEADER_BYTES,
     STATISTICS_ITEMS,
+    STATUS_REQUEST_SPACING_S,
     TASK_CORE_AFFINITY,
     TASK_DISPLAY_NAMES,
     TASK_HEADER_BYTES,
@@ -159,7 +160,7 @@ class StatusMode:
         self.logger.info("Requesting for status ...")
         for index in self.error_items:
             self._status_update(STATISTICS_HEADER_BYTES, index)
-            time.sleep(0.1)
+            time.sleep(STATUS_REQUEST_SPACING_S)
             self.logger.info(
                 "[%s] status update requested", self.error_items[index].message
             )
@@ -170,7 +171,7 @@ class StatusMode:
         """Send status request for task stats."""
         for index in self.task_items:
             self._status_update(TASK_HEADER_BYTES, index)
-            time.sleep(0.1)
+            time.sleep(STATUS_REQUEST_SPACING_S)
             self.logger.info(
                 "[%s] status update requested", self.task_items[index].name
             )

--- a/src/stress_config.py
+++ b/src/stress_config.py
@@ -280,9 +280,40 @@ def _scenario_thresholds_from_dict(d: dict[str, Any]) -> ScenarioThresholds:
     )
 
 
+def _fault_frames_from_names(names: Any, scenario_name: str) -> list[bytes]:
+    """
+    Resolve fault-frame recipe names to their raw byte sequences.
+
+    Raw bytes cannot round-trip through JSON, so a config names the recipes it
+    wants (``"fault_frames": ["bad_checksum", "too_short"]``) and they are
+    looked up in :data:`fault_frames.ALL_RECIPES`.
+    """
+    if not names:
+        return []
+    if not isinstance(names, list):
+        msg = (
+            f"Scenario '{scenario_name}': fault_frames must be a list of recipe "
+            f"names, got {type(names).__name__}"
+        )
+        raise TypeError(msg)
+
+    frames: list[bytes] = []
+    for name in names:
+        if name not in _ff.ALL_RECIPES:
+            known = ", ".join(sorted(_ff.ALL_RECIPES))
+            msg = (
+                f"Scenario '{scenario_name}': unknown fault frame '{name}'. "
+                f"Known recipes: {known}"
+            )
+            raise ValueError(msg)
+        frames.append(_ff.ALL_RECIPES[name])
+    return frames
+
+
 def _scenario_from_dict(d: dict[str, Any]) -> ScenarioConfig:
+    name = d["name"]
     return ScenarioConfig(
-        name=d["name"],
+        name=name,
         duration_s=float(d.get("duration_s", 30.0)),
         command_profile=d.get("command_profile", "echo_only"),
         pacing_s=float(d.get("pacing_s", 0.0)),
@@ -290,7 +321,7 @@ def _scenario_from_dict(d: dict[str, Any]) -> ScenarioConfig:
         num_messages=int(d.get("num_messages", 500)),
         baud_rates=d.get("baud_rates", []),
         noise_bytes=int(d.get("noise_bytes", 64)),
-        fault_frames=[],  # bytes not round-trippable via JSON; set programmatically
+        fault_frames=_fault_frames_from_names(d.get("fault_frames"), name),
         thresholds=_scenario_thresholds_from_dict(d.get("thresholds", {})),
         tags=d.get("tags", []),
     )
@@ -301,6 +332,9 @@ def load_stress_config(path: str | Path) -> StressConfig:
     with Path(path).open(encoding="utf-8") as f:
         data = json.load(f)
     return StressConfig(
-        output_dir=data.get("output_dir", "results"),
+        # Default must match default_stress_config(): the runner only scans
+        # TEST_RESULTS_FOLDER for new artifacts, so a different directory here
+        # makes the reported result_file come back null.
+        output_dir=data.get("output_dir", TEST_RESULTS_FOLDER),
         scenarios=[_scenario_from_dict(s) for s in data.get("scenarios", [])],
     )

--- a/src/stress_test.py
+++ b/src/stress_test.py
@@ -533,9 +533,12 @@ class StressTest(BaseTest):
                 task_snapshot={},
             )
 
+        # This scenario only consumes the statistics delta, so skip the per-task
+        # requests, and carry each frame's "after" snapshot over as the next
+        # frame's "before" instead of polling the device twice per frame.
+        pre = self._request_status_snapshot(include_tasks=False)
         with alive_bar(len(cfg.fault_frames), title=cfg.name) as pbar:
             for idx, frame in enumerate(cfg.fault_frames):
-                pre = self._request_status_snapshot()
                 self.ser.write_raw(frame)
                 logger.info(
                     "Fault frame %d/%d injected: %s",
@@ -544,10 +547,11 @@ class StressTest(BaseTest):
                     frame.hex(),
                 )
                 time.sleep(max(cfg.pacing_s, _MIN_GAP_S))
-                post = self._request_status_snapshot()
+                post = self._request_status_snapshot(include_tasks=False)
                 frame_delta = self._calculate_status_delta(pre, post)["statistics"]
                 for key, val in frame_delta.items():
                     total_delta[key] = total_delta.get(key, 0) + val
+                pre = post
                 pbar()
 
         ended_at = datetime.now(UTC).isoformat()

--- a/src/stress_test.py
+++ b/src/stress_test.py
@@ -162,52 +162,7 @@ class StressTest(BaseTest):
             logger.info("Test interrupted by user")
             return None
 
-        started_at = datetime.now(UTC).isoformat()
-        logger.info(
-            "Starting stress run %s — %d scenario(s)",
-            self._run_id,
-            len(selected_scenarios),
-        )
-
-        self._scenario_results = []
-        total = len(selected_scenarios)
-        for idx, cfg in enumerate(selected_scenarios, start=1):
-            self._emit_progress(
-                "scenario_started",
-                scenario_name=cfg.name,
-                scenario_index=idx,
-                total_scenarios=total,
-            )
-            logger.info("=== Scenario: %s ===", cfg.name)
-            result = self._run_scenario(cfg)
-            self._scenario_results.append(result)
-            logger.info("Scenario '%s' finished: verdict=%s", cfg.name, result.verdict)
-            self._emit_progress(
-                "scenario_finished",
-                scenario_name=cfg.name,
-                scenario_index=idx,
-                total_scenarios=total,
-                verdict=result.verdict,
-                drop_ratio=result.drop_ratio,
-                p95_ms=result.p95_ms,
-            )
-
-        ended_at = datetime.now(UTC).isoformat()
-        overall = aggregate_verdict(self._scenario_results)
-        run_result = StressRunResult(
-            run_id=self._run_id,
-            port=self.ser.port,
-            baudrate=self.ser.baudrate,
-            started_at=started_at,
-            ended_at=ended_at,
-            scenarios=self._scenario_results,
-            overall_verdict=overall,
-        )
-
-        report_path = write_json_report(run_result, self.config.output_dir)
-        logger.info("JSON report: %s", report_path)
-        print_summary(run_result)
-        return run_result
+        return self._execute_scenarios(selected_scenarios)
 
     def execute_test_with_options(
         self,
@@ -219,8 +174,18 @@ class StressTest(BaseTest):
             logger.info("No serial port found. Quitting test.")
             return None
 
-        selected_scenarios = self._resolve_selected_scenarios(scenario_names)
+        return self._execute_scenarios(self._resolve_selected_scenarios(scenario_names))
 
+    def _execute_scenarios(
+        self, selected_scenarios: list[ScenarioConfig]
+    ) -> StressRunResult:
+        """
+        Run the given scenarios, aggregate them, and persist the report.
+
+        A scenario that raises is recorded as a FAIL result and the run
+        continues, so one broken scenario cannot discard the results of every
+        scenario that already completed.
+        """
         started_at = datetime.now(UTC).isoformat()
         logger.info(
             "Starting stress run %s — %d scenario(s)",
@@ -238,7 +203,12 @@ class StressTest(BaseTest):
                 total_scenarios=total,
             )
             logger.info("=== Scenario: %s ===", cfg.name)
-            result = self._run_scenario(cfg)
+            scenario_started_at = datetime.now(UTC).isoformat()
+            try:
+                result = self._run_scenario(cfg)
+            except Exception as exc:  # One scenario must not abort the whole run
+                logger.exception("Scenario '%s' raised; recording FAIL", cfg.name)
+                result = self._make_error_result(cfg, scenario_started_at, exc)
             self._scenario_results.append(result)
             logger.info("Scenario '%s' finished: verdict=%s", cfg.name, result.verdict)
             self._emit_progress(
@@ -267,6 +237,30 @@ class StressTest(BaseTest):
         logger.info("JSON report: %s", report_path)
         print_summary(run_result)
         return run_result
+
+    def _make_error_result(
+        self, cfg: ScenarioConfig, started_at: str, exc: Exception
+    ) -> ScenarioResult:
+        """Build a FAIL ScenarioResult describing a scenario that raised."""
+        return ScenarioResult(
+            name=cfg.name,
+            run_id=self._run_id,
+            started_at=started_at,
+            ended_at=datetime.now(UTC).isoformat(),
+            command_profile=cfg.command_profile,
+            messages_sent=0,
+            messages_received=0,
+            drop_ratio=0.0,
+            latencies_ms=[],
+            p50_ms=0.0,
+            p95_ms=0.0,
+            p99_ms=0.0,
+            status_delta={},
+            task_snapshot={},
+            verdict="FAIL",
+            failure_reasons=[f"scenario raised {type(exc).__name__}: {exc}"],
+            tags=cfg.tags,
+        )
 
     # ------------------------------------------------------------------
     # Scenario dispatcher
@@ -303,8 +297,7 @@ class StressTest(BaseTest):
     def _run_echo_burst(self, cfg: ScenarioConfig) -> ScenarioResult:
         """Send cfg.num_messages echo commands with cfg.pacing_s gap each."""
         started_at = datetime.now(UTC).isoformat()
-        self.latency_msg_sent.clear()
-        self.latency_msg_received.clear()
+        self._reset_latency()
 
         pre = self._request_status_snapshot()
 
@@ -321,14 +314,15 @@ class StressTest(BaseTest):
         post = self._request_status_snapshot()
         ended_at = datetime.now(UTC).isoformat()
 
-        latencies_ms = [v * 1e3 for v in self.latency_msg_received.values()]
+        latencies, sent_count, received_count = self._latency_snapshot()
+        latencies_ms = [v * 1e3 for v in latencies]
         delta = self._calculate_status_delta(pre, post)
         return self._make_result(
             cfg,
             started_at=started_at,
             ended_at=ended_at,
-            messages_sent=len(self.latency_msg_sent),
-            messages_received=len(self.latency_msg_received),
+            messages_sent=sent_count,
+            messages_received=received_count,
             latencies_ms=latencies_ms,
             status_delta=delta["statistics"],
             task_snapshot=post.get("tasks", {}),
@@ -337,8 +331,7 @@ class StressTest(BaseTest):
     def _run_mixed_command_burst(self, cfg: ScenarioConfig) -> ScenarioResult:
         """Randomly interleave echo, statistics, and task status requests."""
         started_at = datetime.now(UTC).isoformat()
-        self.latency_msg_sent.clear()
-        self.latency_msg_received.clear()
+        self._reset_latency()
 
         pre = self._request_status_snapshot()
         echo_counter = 0
@@ -350,9 +343,7 @@ class StressTest(BaseTest):
                     self.publish(echo_counter, cfg.message_length)
                     echo_counter += 1
                 elif cmd == SerialCommand.STATISTICS_STATUS_COMMAND:
-                    has_items = hasattr(self, "STATISTICS_ITEMS")
-                    items_len = len(self.STATISTICS_ITEMS) if has_items else 0
-                    idx = i % items_len if items_len > 0 else 0
+                    idx = i % len(STATISTICS_ITEMS)
                     self._status_update(STATISTICS_HEADER_BYTES, idx)
                 else:
                     idx = i % len(TASK_ITEMS)
@@ -365,14 +356,15 @@ class StressTest(BaseTest):
 
         post = self._request_status_snapshot()
         ended_at = datetime.now(UTC).isoformat()
-        latencies_ms = [v * 1e3 for v in self.latency_msg_received.values()]
+        latencies, _, received_count = self._latency_snapshot()
+        latencies_ms = [v * 1e3 for v in latencies]
         delta = self._calculate_status_delta(pre, post)
         return self._make_result(
             cfg,
             started_at=started_at,
             ended_at=ended_at,
             messages_sent=echo_counter,
-            messages_received=len(self.latency_msg_received),
+            messages_received=received_count,
             latencies_ms=latencies_ms,
             status_delta=delta["statistics"],
             task_snapshot=post.get("tasks", {}),
@@ -388,19 +380,21 @@ class StressTest(BaseTest):
         requests_sent = 0
         with alive_bar(title=cfg.name) as pbar:
             while time.perf_counter() < deadline:
+                # Always honour the minimum gap: with pacing_s = 0 this loop
+                # would otherwise hammer a non-blocking port with no pause,
+                # unlike every other profile.
+                gap = max(cfg.pacing_s, _MIN_GAP_S)
                 for idx in STATISTICS_ITEMS:
                     self._status_update(STATISTICS_HEADER_BYTES, idx)
                     requests_sent += 1
-                    if cfg.pacing_s > 0:
-                        time.sleep(cfg.pacing_s)
+                    time.sleep(gap)
                     pbar()
                     if time.perf_counter() >= deadline:
                         break
                 for idx in TASK_ITEMS:
                     self._status_update(TASK_HEADER_BYTES, idx)
                     requests_sent += 1
-                    if cfg.pacing_s > 0:
-                        time.sleep(cfg.pacing_s)
+                    time.sleep(gap)
                     pbar()
                     if time.perf_counter() >= deadline:
                         break
@@ -443,19 +437,17 @@ class StressTest(BaseTest):
                 # Re-register message handler after baud change re-creates threads
                 self.ser.set_message_handler(lambda c, d, _: self.handle_message(c, d))
 
-                self.latency_msg_sent.clear()
-                self.latency_msg_received.clear()
+                self._reset_latency()
                 for i in range(cfg.num_messages):
                     self.publish(i, cfg.message_length)
                     time.sleep(max(cfg.pacing_s, 0.02))
                     pbar()
                 time.sleep(0.3)
 
-                total_sent += len(self.latency_msg_sent)
-                total_received += len(self.latency_msg_received)
-                all_latencies_ms.extend(
-                    v * 1e3 for v in self.latency_msg_received.values()
-                )
+                latencies, sent_count, received_count = self._latency_snapshot()
+                total_sent += sent_count
+                total_received += received_count
+                all_latencies_ms.extend(v * 1e3 for v in latencies)
 
         # Restore original baud rate
         if self.ser.baudrate != original_baud:
@@ -484,15 +476,13 @@ class StressTest(BaseTest):
 
         # Inject noise directly via the underlying serial port (bypass COBS framing)
         noise_payload = bytes(random.randint(1, 255) for _ in range(cfg.noise_bytes))  # noqa: S311  # Generating random noise, not cryptography
-        if self.ser.ser and self.ser.ser.is_open:
-            self.ser.ser.write(noise_payload)
-            self.ser.ser.flush()
+        if self.ser.is_open():
+            self.ser.write_raw(noise_payload)
             logger.info("Injected %d noise bytes", cfg.noise_bytes)
 
         # Wait briefly then send valid echo messages and measure recovery
         time.sleep(0.1)
-        self.latency_msg_sent.clear()
-        self.latency_msg_received.clear()
+        self._reset_latency()
         recover_start = time.perf_counter()
 
         with alive_bar(cfg.num_messages, title=cfg.name) as pbar:
@@ -504,20 +494,21 @@ class StressTest(BaseTest):
         # Wait up to max_recovery_time_s for all echos to come back
         deadline = recover_start + cfg.thresholds.max_recovery_time_s
         while time.perf_counter() < deadline:
-            if len(self.latency_msg_received) >= cfg.num_messages:
+            if self._latency_snapshot()[2] >= cfg.num_messages:
                 break
             time.sleep(0.01)
 
         post = self._request_status_snapshot()
         ended_at = datetime.now(UTC).isoformat()
-        latencies_ms = [v * 1e3 for v in self.latency_msg_received.values()]
+        latencies, sent_count, received_count = self._latency_snapshot()
+        latencies_ms = [v * 1e3 for v in latencies]
         delta = self._calculate_status_delta(pre, post)
         return self._make_result(
             cfg,
             started_at=started_at,
             ended_at=ended_at,
-            messages_sent=len(self.latency_msg_sent),
-            messages_received=len(self.latency_msg_received),
+            messages_sent=sent_count,
+            messages_received=received_count,
             latencies_ms=latencies_ms,
             status_delta=delta["statistics"],
             task_snapshot=post.get("tasks", {}),
@@ -528,7 +519,7 @@ class StressTest(BaseTest):
         started_at = datetime.now(UTC).isoformat()
         total_delta: dict[str, int] = {}
 
-        if not (self.ser.ser and self.ser.ser.is_open):
+        if not self.ser.is_open():
             logger.warning("Serial port not available for fault injection")
             ended_at = datetime.now(UTC).isoformat()
             return self._make_result(
@@ -545,8 +536,7 @@ class StressTest(BaseTest):
         with alive_bar(len(cfg.fault_frames), title=cfg.name) as pbar:
             for idx, frame in enumerate(cfg.fault_frames):
                 pre = self._request_status_snapshot()
-                self.ser.ser.write(frame)
-                self.ser.ser.flush()
+                self.ser.write_raw(frame)
                 logger.info(
                     "Fault frame %d/%d injected: %s",
                     idx + 1,

--- a/src/visualize_results.py
+++ b/src/visualize_results.py
@@ -43,6 +43,19 @@ from ui_console import console
 logger = logging.getLogger(__name__)
 
 
+def _show_and_close() -> None:
+    """
+    Display the current figure, then release it.
+
+    ``plt.show()`` returns once the window is dismissed but leaves the figure
+    registered with pyplot. Without an explicit close, every visualization in a
+    session accumulates another figure -- pyplot warns past 20 and the memory is
+    never reclaimed.
+    """
+    plt.show()
+    plt.close("all")
+
+
 class VisualizeResults:
     """Class to visualize the log files and plot it."""
 
@@ -433,7 +446,7 @@ class VisualizeResults:
             plt.tight_layout()  # pragma: no mutate
             plt.subplots_adjust(bottom=0.28)  # pragma: no mutate
 
-            plt.show()
+            _show_and_close()
 
         except Exception:
             logger.exception("Error occurred while plotting.")
@@ -525,7 +538,7 @@ class VisualizeResults:
             # Adjust layout to make room for explanation text
             plt.subplots_adjust(bottom=0.18)  # pragma: no mutate
 
-            plt.show()
+            _show_and_close()
 
         except Exception:
             logger.exception("Error occurred while plotting histograms.")
@@ -619,7 +632,7 @@ class VisualizeResults:
             # Adjust layout to make room for explanation text
             plt.subplots_adjust(bottom=0.20)  # pragma: no mutate
 
-            plt.show()
+            _show_and_close()
 
         except Exception:
             logger.exception("Error occurred while plotting controller health.")
@@ -837,7 +850,7 @@ class VisualizeResults:
             )
 
             plt.subplots_adjust(bottom=0.15, right=0.88)  # pragma: no mutate
-            plt.show()
+            _show_and_close()
 
         except Exception:
             logger.exception("Error occurred while plotting error counter details.")
@@ -1034,7 +1047,7 @@ class VisualizeResults:
 
         plt.tight_layout()  # pragma: no mutate
         plt.subplots_adjust(top=0.90)  # pragma: no mutate
-        plt.show()
+        _show_and_close()
 
     def _stress_fig_latency_boxplot(
         self,
@@ -1072,7 +1085,7 @@ class VisualizeResults:
             ax_box.get_xticklabels(), rotation=30, ha="right", fontsize=8
         )  # pragma: no mutate
         plt.tight_layout()  # pragma: no mutate
-        plt.show()
+        _show_and_close()
 
     def _stress_fig_errors_and_verdicts(
         self,
@@ -1192,7 +1205,7 @@ class VisualizeResults:
 
         plt.tight_layout()  # pragma: no mutate
         plt.subplots_adjust(top=0.90, right=0.82)  # pragma: no mutate
-        plt.show()
+        _show_and_close()
 
     def _visualize_stress_task_snapshots(
         self,
@@ -1306,7 +1319,7 @@ class VisualizeResults:
                     )  # pragma: no mutate
 
         plt.tight_layout()  # pragma: no mutate
-        plt.show()
+        _show_and_close()
 
     def execute_visualization(self) -> None:
         """Execute visualization."""

--- a/src/visualize_results.py
+++ b/src/visualize_results.py
@@ -96,9 +96,13 @@ class VisualizeResults:
             current_page = result
 
     def _get_test_files(self) -> list[Path]:
-        """Get sorted list of test files from the tests folder."""
+        """Get sorted list of test files, excluding runner summaries."""
         tests_folder: Path = Path(__file__).parent.parent / TEST_RESULTS_FOLDER
-        return sorted(tests_folder.glob("*.json"))
+        return sorted(
+            p
+            for p in tests_folder.glob("*.json")
+            if not p.name.endswith("-runner.json")
+        )
 
     def _get_page_files(
         self, files: list[Path], current_page: int, page_size: int
@@ -1072,7 +1076,7 @@ class VisualizeResults:
             fontweight="bold",
         )  # pragma: no mutate
         bp = ax_box.boxplot(
-            lat_data, showmeans=True, patch_artist=True, labels=lat_names
+            lat_data, showmeans=True, patch_artist=True, tick_labels=lat_names
         )
         for patch in bp["boxes"]:
             patch.set_facecolor("lightyellow")  # pragma: no mutate

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -31,6 +31,7 @@ from base_test import (
     HEADER_BYTES,
     STATISTICS_HEADER_BYTES,
     STATISTICS_ITEMS,
+    STATUS_REQUEST_SPACING_S,
     TASK_HEADER_BYTES,
     TASK_ITEMS,
     BaseTest,
@@ -996,3 +997,52 @@ class TestLatencyThreadSafety:
         base._reset_latency()
 
         assert base._latency_snapshot() == ([], 0, 0)
+
+
+class TestStatusSnapshotCost:
+    """Pacing dominates snapshot cost, so the request count matters."""
+
+    @staticmethod
+    def _tester() -> BaseTest:
+        base = BaseTest(Mock(spec=SerialInterface))
+        # Mark every slot as fresh so the collection loop exits immediately.
+        for idx in STATISTICS_ITEMS:
+            base._statistics_updated_at[idx] = float("inf")
+        for idx in TASK_ITEMS:
+            base._task_updated_at[idx] = float("inf")
+        return base
+
+    def test_full_snapshot_requests_every_item(self) -> None:
+        """The default still polls all statistics and task slots."""
+        base = self._tester()
+        with patch.object(base, "_status_update") as upd, patch("base_test.time.sleep"):
+            result = base._request_status_snapshot()
+        assert upd.call_count == len(STATISTICS_ITEMS) + len(TASK_ITEMS)
+        assert result["complete"] is True
+        assert set(result["tasks"]) == set(TASK_ITEMS.values())
+
+    def test_stats_only_snapshot_skips_task_requests(self) -> None:
+        """include_tasks=False drops the per-task round-trips entirely."""
+        base = self._tester()
+        with patch.object(base, "_status_update") as upd, patch("base_test.time.sleep"):
+            result = base._request_status_snapshot(include_tasks=False)
+        assert upd.call_count == len(STATISTICS_ITEMS)
+        assert result["tasks"] == {}
+        # Completeness must not be judged against tasks that were never asked for.
+        assert result["complete"] is True
+        assert result["received"]["tasks"] == 0
+
+    def test_no_trailing_sleep_after_last_request(self) -> None:
+        """The gap is only needed between requests, not after the final one."""
+        base = self._tester()
+        with (
+            patch.object(base, "_status_update"),
+            patch("base_test.time.sleep") as sleep_mock,
+        ):
+            base._request_status_snapshot(include_tasks=False)
+        pacing_sleeps = [
+            c
+            for c in sleep_mock.call_args_list
+            if c.args == (STATUS_REQUEST_SPACING_S,)
+        ]
+        assert len(pacing_sleeps) == len(STATISTICS_ITEMS) - 1

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -903,3 +903,96 @@ class TestStatusDeltaMissingKeys:
         # Other stats should be 0 - 0 = 0
         second_stat = list(STATISTICS_ITEMS.values())[1]
         assert delta["statistics"][second_stat] == 0
+
+
+class TestBooleanPromptParsing:
+    """Boolean prompts must be parseable as words, not cast via bool()."""
+
+    @pytest.mark.parametrize(
+        ("entered", "expected"),
+        [
+            ("False", False),
+            ("false", False),
+            ("no", False),
+            ("n", False),
+            ("0", False),
+            ("anything else", False),
+            ("True", True),
+            ("true", True),
+            ("yes", True),
+            ("y", True),
+            ("1", True),
+            ("  TRUE  ", True),
+        ],
+    )
+    def test_bool_input_parsed_by_word(self, entered: str, *, expected: bool) -> None:
+        """bool("False") is True, so a plain cast would make "no" impossible."""
+        base = BaseTest(Mock())
+        with patch("base_test.console.input", return_value=entered):
+            assert base._get_user_input("Enable?", default_value=False) is expected
+
+    def test_bool_empty_input_keeps_default(self) -> None:
+        """An empty answer keeps whichever default was offered."""
+        base = BaseTest(Mock())
+        with patch("base_test.console.input", return_value=""):
+            assert base._get_user_input("Enable?", default_value=True) is True
+            assert base._get_user_input("Enable?", default_value=False) is False
+
+    def test_invalid_numeric_input_falls_back_to_default(self) -> None:
+        """A non-numeric answer must not abort the whole mode."""
+        base = BaseTest(Mock())
+        with patch("base_test.console.input", return_value="abc"):
+            assert base._get_user_input("Samples", 255) == 255
+            assert base._get_user_input("Wait", 1.5) == 1.5
+
+    def test_valid_numeric_input_still_cast(self) -> None:
+        """Normal numeric entry keeps working."""
+        base = BaseTest(Mock())
+        with patch("base_test.console.input", return_value="42"):
+            assert base._get_user_input("Samples", 255) == 42
+
+
+class TestLatencyThreadSafety:
+    """The latency dicts are written from the processing thread."""
+
+    def test_snapshot_stable_while_echoes_arrive(self) -> None:
+        """_latency_snapshot must not raise while handle_message inserts."""
+        base = BaseTest(Mock())
+        stop = threading.Event()
+
+        def writer() -> None:
+            counter = 0
+            while not stop.is_set():
+                # Cycle over a bounded key range: an ever-growing dict would
+                # make each snapshot copy progressively slower, not more racy.
+                key = counter % 64
+                with base._latency_lock:
+                    base.latency_msg_sent[key] = 0.0
+                    base.latency_msg_received[key] = 0.001
+                    if key == 0:
+                        base.latency_msg_sent.clear()
+                        base.latency_msg_received.clear()
+                counter += 1
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        try:
+            for _ in range(2000):
+                # Copying the live dict here would raise
+                # "dictionary changed size during iteration".
+                latencies, sent, received = base._latency_snapshot()
+                assert len(latencies) == received
+                assert sent >= received
+        finally:
+            stop.set()
+            thread.join(timeout=5)
+
+    def test_reset_clears_both_dicts(self) -> None:
+        """_reset_latency replaces the paired clear() calls."""
+        base = BaseTest(Mock())
+        base.latency_msg_sent[1] = 0.0
+        base.latency_msg_received[1] = 0.5
+
+        base._reset_latency()
+
+        assert base._latency_snapshot() == ([], 0, 0)

--- a/tests/test_command_mode.py
+++ b/tests/test_command_mode.py
@@ -485,9 +485,14 @@ class TestDisplayThreadResilience:
             mode.handle_message(1, b"", b"")  # raises inside the loop
             mode.handle_message(2, b"", b"")
             mode.handle_message(3, b"", b"")
-            thread = threading.Thread(target=mode._process_messages)
+            # daemon=True so a mutant that breaks the loop's exit condition
+            # cannot leave a live thread holding the interpreter open.
+            thread = threading.Thread(target=mode._process_messages, daemon=True)
             thread.start()
-            thread.join(timeout=5)
+            try:
+                thread.join(timeout=5)
+            finally:
+                mode.running = False
 
         assert not thread.is_alive()
         # Frames after the exception were still processed.

--- a/tests/test_command_mode.py
+++ b/tests/test_command_mode.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import queue
+import threading
 from io import StringIO
 from unittest.mock import Mock, patch
 
@@ -429,3 +431,74 @@ class TestExecuteCommandModeAdditional:
             command_mode.execute_command_mode()
 
         assert command_mode.running is False
+
+
+class TestDisplayThreadResilience:
+    """A malformed frame must not kill the display thread."""
+
+    @staticmethod
+    def _make_mode() -> CommandMode:
+        ser = Mock(spec=SerialInterface)
+        ser.is_open.return_value = True
+        return CommandMode(ser)
+
+    def test_undecodable_frame_does_not_raise(self) -> None:
+        """cobs.decode() raised DecodeError straight out of the handler."""
+        mode = self._make_mode()
+        # b"\x00" is not a valid COBS body.
+        mode._handle_message(SerialCommand.ECHO_COMMAND.value, b"\x00\x34", b"\x00")
+
+    def test_truncated_key_frame_does_not_raise(self) -> None:
+        """A KEY frame shorter than 4 bytes used to raise IndexError."""
+        mode = self._make_mode()
+        mode._print_decoded_message(
+            bytes([0x00, SerialCommand.KEY_COMMAND.value, 0x00])
+        )
+
+    def test_truncated_analog_frame_does_not_raise(self) -> None:
+        """An ANALOG frame shorter than 6 bytes used to raise IndexError."""
+        mode = self._make_mode()
+        mode._print_decoded_message(
+            bytes([0x00, SerialCommand.ANALOG_COMMAND.value, 0x00, 0x01])
+        )
+
+    def test_frame_shorter_than_header_does_not_raise(self) -> None:
+        """Even a 1-byte frame must be handled."""
+        mode = self._make_mode()
+        mode._print_decoded_message(b"\x00")
+
+    def test_process_messages_survives_handler_exception(self) -> None:
+        """The loop keeps draining after a frame that blows up."""
+        mode = self._make_mode()
+        mode.running = True
+        seen: list[int] = []
+
+        def handler(command: int, _decoded: bytes, _raw: bytes) -> None:
+            if command == 1:
+                msg = "bad frame"
+                raise ValueError(msg)
+            seen.append(command)
+            if command == 3:
+                mode.running = False
+
+        with patch.object(mode, "_handle_message", side_effect=handler):
+            mode.handle_message(1, b"", b"")  # raises inside the loop
+            mode.handle_message(2, b"", b"")
+            mode.handle_message(3, b"", b"")
+            thread = threading.Thread(target=mode._process_messages)
+            thread.start()
+            thread.join(timeout=5)
+
+        assert not thread.is_alive()
+        # Frames after the exception were still processed.
+        assert seen == [2, 3]
+
+    def test_full_queue_drops_instead_of_blocking(self) -> None:
+        """handle_message runs on the serial thread and must never block."""
+        mode = self._make_mode()
+        mode.message_queue = queue.Queue(maxsize=1)
+
+        mode.handle_message(1, b"", b"")
+        mode.handle_message(2, b"", b"")  # dropped, must return immediately
+
+        assert mode.message_queue.qsize() == 1

--- a/tests/test_latency_test.py
+++ b/tests/test_latency_test.py
@@ -32,6 +32,7 @@ from base_test import (
     DEFAULT_SAMPLES,
     DEFAULT_WAIT_TIME,
     HEADER_BYTES,
+    MAX_SAMPLE_SIZE,
 )
 from latency_test import (
     DEFAULT_MIN_WAIT,
@@ -587,3 +588,50 @@ def test_main_test_nonzero_wait_values() -> None:
     wait_0 = out[0]["waiting_time"]
     wait_1 = out[1]["waiting_time"]
     assert wait_0 != pytest.approx(wait_1, abs=1e-9)
+
+
+class TestRunSizeValidation:
+    """Guards on iteration and sample counts."""
+
+    def test_single_iteration_does_not_divide_by_zero(
+        self, latency_tester: LatencyTest
+    ) -> None:
+        """num_times=1 made the ramp compute j / (num_times - 1)."""
+        tester = latency_tester
+        tester.ser.baudrate = 115200
+        with (
+            patch.object(tester, "_request_status_snapshot", return_value={}),
+            patch.object(tester, "_calculate_status_delta", return_value={}),
+            patch.object(tester, "_write_output_to_file"),
+            patch("latency_test.time.sleep"),
+        ):
+            # Must complete instead of raising ZeroDivisionError.
+            tester.main_test(num_times=1, samples=2, wait_time=0, length=6)
+
+    @pytest.mark.parametrize("num_times", [0, -1])
+    def test_non_positive_num_times_falls_back(self, num_times: int) -> None:
+        """Zero or negative iteration counts fall back to the default."""
+        resolved, _ = LatencyTest._validate_run_size(num_times, 255)
+        assert resolved == DEFAULT_NUM_TIMES
+
+    @pytest.mark.parametrize("samples", [0, -5, MAX_SAMPLE_SIZE, MAX_SAMPLE_SIZE + 1])
+    def test_out_of_range_samples_falls_back(self, samples: int) -> None:
+        """publish() packs the counter into two bytes, so 65536 would overflow."""
+        _, resolved = LatencyTest._validate_run_size(5, samples)
+        assert resolved == DEFAULT_SAMPLES
+
+    def test_in_range_values_pass_through(self) -> None:
+        """Valid values are left untouched."""
+        assert LatencyTest._validate_run_size(3, 100) == (3, 100)
+        assert LatencyTest._validate_run_size(1, MAX_SAMPLE_SIZE - 1) == (
+            1,
+            MAX_SAMPLE_SIZE - 1,
+        )
+
+    def test_oversized_samples_would_overflow_publish(
+        self, latency_tester: LatencyTest
+    ) -> None:
+        """Documents why the ceiling exists."""
+        tester = latency_tester
+        with pytest.raises(OverflowError):
+            tester.publish(MAX_SAMPLE_SIZE, 10)

--- a/tests/test_latency_test.py
+++ b/tests/test_latency_test.py
@@ -43,6 +43,27 @@ from result_format import FORMAT_LATENCY_SERIES
 from serial_interface import SerialCommand, SerialInterface
 
 
+class DummyBar:
+    """
+    Stand-in for ``alive_bar`` in tests that drive a full test loop.
+
+    The real progress bar resolves ``sys.stdout.fileno()`` on entry, which
+    raises ``ValueError: I/O operation on closed file`` under runners that
+    close stdout (notably ``mutmut``'s clean-test pass). Any test that calls
+    ``main_test`` must patch ``latency_test.alive_bar`` with this.
+    """
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        """Accept and ignore whatever alive_bar was called with."""
+
+    def __enter__(self) -> Any:
+        """Return a no-op progress callback."""
+        return lambda: None
+
+    def __exit__(self, *_: object) -> None:
+        """Nothing to tear down."""
+
+
 @pytest.fixture
 def latency_tester() -> LatencyTest:
     """LatencyTest with a mocked SerialInterface."""
@@ -316,15 +337,6 @@ def test_main_test_collects_and_writes_output() -> None:
     mock_ser.baudrate = 115200
     tester = LatencyTest(mock_ser)
 
-    # Replace progress bar with a no-op context manager
-    class DummyBar:
-        def __init__(self, *_: Any, **__: Any) -> None: ...
-        def __enter__(self) -> Any:
-            return lambda: None
-
-        def __exit__(self, *_: object) -> None:
-            return None
-
     # Use a monotonic counter for perf_counter to avoid zero elapsed time
     t = {"v": 0.0}
 
@@ -391,14 +403,6 @@ def test_main_test_with_jitter_path() -> None:
     mock_ser = Mock(spec=SerialInterface)
     mock_ser.baudrate = 115200
     tester = LatencyTest(mock_ser)
-
-    class DummyBar:
-        def __init__(self, *_: Any, **__: Any) -> None: ...
-        def __enter__(self) -> Any:
-            return lambda: None
-
-        def __exit__(self, *_: object) -> None:
-            return None
 
     t = {"v": 0.0}
 
@@ -543,14 +547,6 @@ def test_main_test_nonzero_wait_values() -> None:
     mock_ser.baudrate = 115200
     tester = LatencyTest(mock_ser)
 
-    class DummyBar:
-        def __init__(self, *_: Any, **__: Any) -> None: ...
-        def __enter__(self) -> Any:
-            return lambda: None
-
-        def __exit__(self, *_: object) -> None:
-            return None
-
     t = {"v": 0.0}
 
     def fake_perf_counter() -> float:
@@ -600,6 +596,7 @@ class TestRunSizeValidation:
         tester = latency_tester
         tester.ser.baudrate = 115200
         with (
+            patch("latency_test.alive_bar", DummyBar),
             patch.object(tester, "_request_status_snapshot", return_value={}),
             patch.object(tester, "_calculate_status_delta", return_value={}),
             patch.object(tester, "_write_output_to_file"),

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -22,7 +22,11 @@ import logging.handlers
 import os
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import pytest
 
@@ -30,6 +34,39 @@ from logger_config import _Dispatch, _install_queue_dispatch, setup_logging
 
 
 class TestSetupLogging:
+    @pytest.fixture(autouse=True)
+    def _fresh_process(self) -> Iterator[None]:
+        """setup_logging configures once per process; start each test unset."""
+        previous = _Dispatch.configured
+        _Dispatch.configured = False
+        try:
+            yield
+        finally:
+            _Dispatch.configured = previous
+
+    def test_repeat_calls_are_ignored(self) -> None:
+        """Eight modules call this at import; only the first may reconfigure."""
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch("logging.config.fileConfig") as mock_file_config,
+        ):
+            setup_logging()
+            setup_logging()
+            setup_logging()
+
+        mock_file_config.assert_called_once()
+
+    def test_force_reconfigures(self) -> None:
+        """An explicit force=True still re-reads the configuration."""
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch("logging.config.fileConfig") as mock_file_config,
+        ):
+            setup_logging()
+            setup_logging(force=True)
+
+        assert mock_file_config.call_count == 2
+
     def test_loads_config_when_file_exists(self) -> None:
         with (
             patch.object(Path, "exists", return_value=True),

--- a/tests/test_regression_test.py
+++ b/tests/test_regression_test.py
@@ -21,7 +21,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from regression_test import RegressionTest
+from checksum import calculate_checksum
+from regression_test import ECHO_PAYLOAD, RegressionTest
 from serial_interface import SerialCommand, SerialInterface
 
 
@@ -283,3 +284,44 @@ class TestExecuteTestCallsEcho:
         ) as spy:
             regression_test.execute_test()
         spy.assert_called_once()
+
+
+class TestEchoReplyCarriesChecksum:
+    """The device echoes payload + trailing XOR checksum, not the bare payload."""
+
+    def _capture(self, tester: RegressionTest, decoded: bytes) -> list[str]:
+        logged: list[str] = []
+        with patch("regression_test.logger") as mock_log:
+            mock_log.info.side_effect = lambda msg, *args: logged.append(
+                msg % args if args else msg
+            )
+            tester.handle_message(SerialCommand.ECHO_COMMAND.value, decoded, b"raw")
+        return logged
+
+    def test_reply_with_checksum_byte_reports_ok(
+        self, regression_test: RegressionTest
+    ) -> None:
+        """A full frame (payload + checksum) is the real shape off the wire."""
+        reply = ECHO_PAYLOAD + calculate_checksum(ECHO_PAYLOAD)
+        assert len(reply) == len(ECHO_PAYLOAD) + 1
+
+        logged = self._capture(regression_test, reply)
+
+        assert any("[OK] Echo command" in m for m in logged)
+        assert not any("[FAIL]" in m for m in logged)
+
+    def test_corrupted_payload_still_reports_fail(
+        self, regression_test: RegressionTest
+    ) -> None:
+        """Stripping the checksum must not make every reply look correct."""
+        wrong = bytes([0x00, 0x34, 0x02, 0x01, 0xFF])
+        logged = self._capture(regression_test, wrong + calculate_checksum(wrong))
+
+        assert any("[FAIL] Echo command" in m for m in logged)
+
+    def test_echo_command_sends_the_expected_payload(
+        self, regression_test: RegressionTest, mock_serial: Mock
+    ) -> None:
+        """The payload compared against is the one actually transmitted."""
+        regression_test.test_echo_command()
+        mock_serial.write.assert_called_once_with(ECHO_PAYLOAD)

--- a/tests/test_serial_interface.py
+++ b/tests/test_serial_interface.py
@@ -18,6 +18,8 @@
 from __future__ import annotations
 
 import logging
+import queue
+import threading
 from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, patch
 
@@ -25,7 +27,7 @@ import serial
 from cobs import cobs
 
 from checksum import calculate_checksum
-from serial_interface import SerialCommand, SerialInterface
+from serial_interface import SerialCommand, SerialInterface, SerialStatistics
 
 if TYPE_CHECKING:
     import pytest
@@ -484,3 +486,148 @@ def test_threads_are_daemon() -> None:
     si = make_interface()
     assert si.read_thread.daemon is True
     assert si.processing_thread.daemon is True
+
+
+class TestResilienceFixes:
+    """Regression tests for the resilience and thread-safety hardening."""
+
+    def test_close_without_start_reading_does_not_raise(self) -> None:
+        """close() must tolerate threads that were never started."""
+        si = make_interface()
+        si.ser = Mock()
+        # Threads are constructed in __init__ but never started; joining an
+        # unstarted thread raises RuntimeError, so close() must skip them.
+        si.close()
+        si.ser.close.assert_called_once()
+
+    def test_close_gives_up_on_wedged_thread(self) -> None:
+        """A thread that never stops is abandoned instead of hanging close()."""
+        si = make_interface()
+        si.ser = Mock()
+        stuck = Mock()
+        stuck.is_alive.return_value = True
+        stuck.name = "stuck-thread"
+        si.read_thread = stuck
+        si.processing_thread = None  # type: ignore[assignment]
+
+        si.close()
+
+        stuck.join.assert_called_once_with(timeout=SerialInterface.JOIN_TIMEOUT_S)
+        si.ser.close.assert_called_once()
+
+    def test_write_swallows_timeout_exception(self) -> None:
+        """A full output buffer must not propagate into the caller's loop."""
+        si = make_interface()
+        ser_mock = Mock()
+        ser_mock.write.side_effect = serial.SerialTimeoutException("full")
+        si.ser = ser_mock
+
+        si.write(b"\x00\x34\x02\x01\x02")  # must not raise
+
+    def test_write_swallows_serial_exception(self) -> None:
+        """A disconnected cable must not propagate into the caller's loop."""
+        si = make_interface()
+        ser_mock = Mock()
+        ser_mock.write.side_effect = serial.SerialException("gone")
+        si.ser = ser_mock
+
+        si.write(b"\x00\x34\x02\x01\x02")  # must not raise
+
+    def test_write_raw_bypasses_framing_and_counts_bytes(self) -> None:
+        """write_raw puts bytes on the wire verbatim and tracks them."""
+        si = make_interface()
+        ser_mock = Mock()
+        ser_mock.write.side_effect = len
+        si.ser = ser_mock
+
+        payload = bytes([0x01] * 26)
+        si.write_raw(payload)
+
+        ser_mock.write.assert_called_once_with(payload)
+        ser_mock.flush.assert_called_once()
+        assert si.statistics.snapshot()["bytes_sent"] == len(payload)
+
+    def test_write_raw_swallows_serial_exception(self) -> None:
+        """Raw injection failures are logged, not raised."""
+        si = make_interface()
+        ser_mock = Mock()
+        ser_mock.write.side_effect = serial.SerialException("gone")
+        si.ser = ser_mock
+
+        si.write_raw(b"\x01\x02")  # must not raise
+
+    def test_full_queue_drops_frame_instead_of_blocking(self) -> None:
+        """A saturated queue sheds frames rather than stalling the read thread."""
+        si = make_interface()
+        si.message_queue = queue.Queue(maxsize=1)
+
+        si._enqueue_message(b"first")
+        si._enqueue_message(b"second")  # dropped, must not block
+
+        assert si.message_queue.qsize() == 1
+        assert si.statistics.snapshot()["dropped_frames"] == 1
+
+    def test_checksum_mismatch_counted_but_dispatched_by_default(self) -> None:
+        """With verification off, a bad checksum is counted and still delivered."""
+        si = make_interface()
+        seen: list[int] = []
+        si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
+
+        body = bytes([0x00, SerialCommand.KEY_COMMAND.value, 0x02, 0x11])
+        frame = cobs.encode(body + b"\xff")  # deliberately wrong checksum
+        si._process_complete_message(frame)
+
+        assert seen == [SerialCommand.KEY_COMMAND.value]
+        assert si.statistics.snapshot()["checksum_mismatches"] == 1
+
+    def test_checksum_mismatch_dropped_when_verification_enabled(self) -> None:
+        """With verification on, a bad checksum frame is not dispatched."""
+        si = SerialInterface(
+            port="COM1", baudrate=115200, timeout=0.1, verify_checksum=True
+        )
+        seen: list[int] = []
+        si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
+
+        body = bytes([0x00, SerialCommand.KEY_COMMAND.value, 0x02, 0x11])
+        frame = cobs.encode(body + b"\xff")
+        si._process_complete_message(frame)
+
+        assert seen == []
+        assert si.statistics.snapshot()["checksum_mismatches"] == 1
+
+    def test_valid_checksum_dispatched_when_verification_enabled(self) -> None:
+        """A correctly checksummed frame passes verification."""
+        si = SerialInterface(
+            port="COM1", baudrate=115200, timeout=0.1, verify_checksum=True
+        )
+        seen: list[int] = []
+        si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
+
+        body = bytes([0x00, SerialCommand.KEY_COMMAND.value, 0x02, 0x11])
+        frame = cobs.encode(body + calculate_checksum(body))
+        si._process_complete_message(frame)
+
+        assert seen == [SerialCommand.KEY_COMMAND.value]
+        assert si.statistics.snapshot()["checksum_mismatches"] == 0
+
+    def test_statistics_snapshot_stable_under_concurrent_writes(self) -> None:
+        """snapshot() must not raise while another thread adds command keys."""
+        stats = SerialStatistics()
+        stop = threading.Event()
+
+        def writer() -> None:
+            command = 0
+            while not stop.is_set():
+                stats.record_received_command(command % 32)
+                command += 1
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        try:
+            for _ in range(2000):
+                # Iterating the live defaultdict here would raise
+                # "dictionary changed size during iteration".
+                assert isinstance(stats.snapshot()["commands_received"], dict)
+        finally:
+            stop.set()
+            thread.join(timeout=5)

--- a/tests/test_serial_interface.py
+++ b/tests/test_serial_interface.py
@@ -160,7 +160,8 @@ def test_process_complete_message_success_calls_handler() -> None:
         called["raw"] = raw
 
     si.set_message_handler(handler)
-    decoded = b"\xaa" + bytes([SerialCommand.KEY_COMMAND.value]) + b"XYZ"
+    body = b"\xaa" + bytes([SerialCommand.KEY_COMMAND.value]) + b"XYZ"
+    decoded = body + calculate_checksum(body)
     raw = cobs.encode(decoded)
     si._process_complete_message(raw)
 
@@ -187,36 +188,33 @@ def test_process_complete_message_decode_error_logs(
 
 
 def test_handle_received_data_queue_and_rts_toggle() -> None:
-    """Test handling received data queues messages and toggles RTS based on buffer."""
+    """Received data is framed into the queue and RTS tracks consumer lag."""
     si = make_interface()
-    # Shrink watermarks for the test
-    si.BUFFER_HIGH_WATER = 3  # pyright: ignore[reportAttributeAccessIssue]
-    si.BUFFER_LOW_WATER = 1  # pyright: ignore[reportAttributeAccessIssue]
+    # Shrink watermarks so the test does not need thousands of frames.
+    si.QUEUE_HIGH_WATER = 2  # pyright: ignore[reportAttributeAccessIssue]
+    si.QUEUE_LOW_WATER = 1  # pyright: ignore[reportAttributeAccessIssue]
     ser_mock = Mock()
     ser_mock.rts = True
     si.ser = ser_mock
 
-    # Pre-fill buffer beyond high watermark so the first check disables RTS
-    si.buffer = bytearray(b"XXXX")
-    si._handle_received_data(
-        b"\x00", max_message_size=100
-    )  # Clear buffer, queue 'XXXX'
+    # Backlog past the high watermark: tell the sender to stop.
+    for _ in range(3):
+        si.message_queue.put(b"backlog")
+    si._handle_received_data(b"", max_message_size=100)
     assert ser_mock.rts is False
-    assert si.buffer == bytearray()
 
-    # Next call sees buffer below low watermark, enabling RTS
+    # Consumer catches up below the low watermark: allow sending again.
+    while not si.message_queue.empty():
+        si.message_queue.get_nowait()
     si._handle_received_data(b"", max_message_size=100)
     assert ser_mock.rts is True
 
-    # Send a valid message (COBS encoded + delimiter) and ensure it lands in queue
+    # A valid message (COBS encoded + delimiter) still lands in the queue.
     msg = cobs.encode(b"hi")
     si._handle_received_data(msg + b"\x00", max_message_size=100)
-    # First queued item was the prefill ('XXXX'), discard it
-    first = si.message_queue.get(timeout=0.5)
-    assert first == b"XXXX"
     out = si.message_queue.get(timeout=0.5)
     assert out == msg
-    assert si.statistics.bytes_received >= len(msg) + 1
+    assert si.statistics.snapshot()["bytes_received"] >= len(msg) + 1
 
 
 def test_handle_received_data_max_size_warning(
@@ -335,7 +333,8 @@ class TestProcessMessages:
 
         si.set_message_handler(handler)
 
-        decoded = b"\xaa" + bytes([SerialCommand.ECHO_COMMAND.value]) + b"payload"
+        body = b"\xaa" + bytes([SerialCommand.ECHO_COMMAND.value]) + b"payload"
+        decoded = body + calculate_checksum(body)
         raw = cobs.encode(decoded)
         si.message_queue.put(raw)
 
@@ -347,45 +346,69 @@ class TestProcessMessages:
 
 
 class TestFlowControlBoundaries:
-    """Test _handle_received_data at exact watermark boundaries."""
+    """RTS reacts to queue depth, at the exact watermark boundaries."""
 
-    def test_buffer_at_high_water_does_not_deassert_rts(self) -> None:
+    @staticmethod
+    def _with_pending(pending: int, *, rts: bool) -> tuple[SerialInterface, Mock]:
+        si = make_interface()
+        ser_mock = Mock()
+        ser_mock.rts = rts
+        si.ser = ser_mock
+        for _ in range(pending):
+            si.message_queue.put(b"x")
+        return si, ser_mock
+
+    def test_queue_at_high_water_does_not_deassert_rts(self) -> None:
+        """Comparison is '>' so exactly at the watermark must not stop the sender."""
+        si, ser_mock = self._with_pending(SerialInterface.QUEUE_HIGH_WATER, rts=True)
+        si._handle_received_data(b"", max_message_size=2048)
+        assert ser_mock.rts is True
+
+    def test_queue_above_high_water_deasserts_rts(self) -> None:
+        """One frame past the watermark applies backpressure."""
+        si, ser_mock = self._with_pending(
+            SerialInterface.QUEUE_HIGH_WATER + 1, rts=True
+        )
+        si._handle_received_data(b"", max_message_size=2048)
+        assert ser_mock.rts is False
+
+    def test_queue_at_low_water_does_not_assert_rts(self) -> None:
+        """Comparison is '<' so exactly at the watermark must not release yet."""
+        si, ser_mock = self._with_pending(SerialInterface.QUEUE_LOW_WATER, rts=False)
+        si._handle_received_data(b"", max_message_size=2048)
+        assert ser_mock.rts is False
+
+    def test_queue_below_low_water_asserts_rts(self) -> None:
+        """Once the consumer catches up, the sender is released."""
+        si, ser_mock = self._with_pending(
+            SerialInterface.QUEUE_LOW_WATER - 1, rts=False
+        )
+        si._handle_received_data(b"", max_message_size=2048)
+        assert ser_mock.rts is True
+
+    def test_ordinary_frame_never_engages_flow_control(self) -> None:
         """
-        Buffer size == BUFFER_HIGH_WATER should NOT trigger RTS deassert.
+        The regression this fix targets.
 
-        The code uses '>' (strictly greater), so exactly at the watermark
-        should not deassert RTS.
+        Watermarks used to be compared against ``self.buffer``, the partial-frame
+        accumulator that is cleared at every delimiter. A normal ~12-byte frame
+        never came close to 768 bytes, so RTS effectively never engaged.
         """
         si = make_interface()
         ser_mock = Mock()
         ser_mock.rts = True
         si.ser = ser_mock
 
-        # Pre-fill buffer to exactly BUFFER_HIGH_WATER
-        si.buffer = bytearray(b"X" * si.BUFFER_HIGH_WATER)
-        si._handle_received_data(b"\x00", max_message_size=2048)
+        frame = cobs.encode(b"\x00\x34\x02\x01\x02") + b"\x00"
+        for _ in range(50):
+            si._handle_received_data(frame, max_message_size=2048)
 
-        # RTS should still be True (not deasserted) because == not >
+        # 50 undelivered frames is well below the queue watermark: no backpressure.
         assert ser_mock.rts is True
-
-    def test_buffer_at_low_water_does_not_assert_rts(self) -> None:
-        """
-        Buffer size == BUFFER_LOW_WATER should NOT trigger RTS assert.
-
-        The code uses '<' (strictly less), so exactly at the watermark
-        should not reassert RTS.
-        """
-        si = make_interface()
-        ser_mock = Mock()
-        ser_mock.rts = False  # Start with RTS deasserted
-        si.ser = ser_mock
-
-        # Pre-fill buffer to exactly BUFFER_LOW_WATER
-        si.buffer = bytearray(b"X" * si.BUFFER_LOW_WATER)
-        si._handle_received_data(b"\x00", max_message_size=2048)
-
-        # RTS should remain False because == not <
-        assert ser_mock.rts is False
+        assert si.message_queue.qsize() == 50
+        # And the accumulator is empty between frames, which is why it was useless
+        # as a backpressure signal.
+        assert si.buffer == bytearray()
 
 
 class TestWriteEncoding:
@@ -567,9 +590,10 @@ class TestResilienceFixes:
         assert si.message_queue.qsize() == 1
         assert si.statistics.snapshot()["dropped_frames"] == 1
 
-    def test_checksum_mismatch_counted_but_dispatched_by_default(self) -> None:
-        """With verification off, a bad checksum is counted and still delivered."""
+    def test_checksum_mismatch_dropped_by_default(self) -> None:
+        """Verification is on by default, so a corrupt frame is not delivered."""
         si = make_interface()
+        assert si.verify_checksum is True
         seen: list[int] = []
         si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
 
@@ -577,13 +601,15 @@ class TestResilienceFixes:
         frame = cobs.encode(body + b"\xff")  # deliberately wrong checksum
         si._process_complete_message(frame)
 
-        assert seen == [SerialCommand.KEY_COMMAND.value]
+        assert seen == []
         assert si.statistics.snapshot()["checksum_mismatches"] == 1
+        # A dropped frame must not inflate the received-command counters.
+        assert si.statistics.snapshot()["commands_received"] == {}
 
-    def test_checksum_mismatch_dropped_when_verification_enabled(self) -> None:
-        """With verification on, a bad checksum frame is not dispatched."""
+    def test_checksum_mismatch_dispatched_when_verification_disabled(self) -> None:
+        """The opt-out still counts mismatches but keeps delivering frames."""
         si = SerialInterface(
-            port="COM1", baudrate=115200, timeout=0.1, verify_checksum=True
+            port="COM1", baudrate=115200, timeout=0.1, verify_checksum=False
         )
         seen: list[int] = []
         si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
@@ -592,14 +618,12 @@ class TestResilienceFixes:
         frame = cobs.encode(body + b"\xff")
         si._process_complete_message(frame)
 
-        assert seen == []
+        assert seen == [SerialCommand.KEY_COMMAND.value]
         assert si.statistics.snapshot()["checksum_mismatches"] == 1
 
-    def test_valid_checksum_dispatched_when_verification_enabled(self) -> None:
+    def test_valid_checksum_dispatched(self) -> None:
         """A correctly checksummed frame passes verification."""
-        si = SerialInterface(
-            port="COM1", baudrate=115200, timeout=0.1, verify_checksum=True
-        )
+        si = make_interface()
         seen: list[int] = []
         si.set_message_handler(lambda cmd, _d, _r: seen.append(cmd))
 

--- a/tests/test_status_mode.py
+++ b/tests/test_status_mode.py
@@ -21,8 +21,9 @@ import datetime
 import logging
 import time
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
+
+import pytest
 
 from base_test import STATISTICS_HEADER_BYTES
 from serial_interface import SerialCommand, SerialInterface
@@ -30,9 +31,6 @@ from status_mode import (
     _TASK_INDEX_BY_NAME,
     StatusMode,
 )
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class DummyStats:
@@ -44,6 +42,17 @@ class DummyStats:
         self.bytes_sent = 0
         self.commands_sent: dict[int, int] = {}
         self.commands_received: dict[int, int] = {}
+
+    def snapshot(self) -> dict[str, object]:
+        """Mirror SerialStatistics.snapshot()."""
+        return {
+            "bytes_received": self.bytes_received,
+            "bytes_sent": self.bytes_sent,
+            "commands_sent": dict(self.commands_sent),
+            "commands_received": dict(self.commands_received),
+            "dropped_frames": 0,
+            "checksum_mismatches": 0,
+        }
 
 
 def make_status_mode() -> StatusMode:
@@ -478,3 +487,26 @@ def test_base_test_snapshot_includes_heap() -> None:
         result = bt._request_status_snapshot(timeout_s=1.0)
 
     assert result["min_free_heap_bytes"] == 42_000
+
+
+class TestCommandLabel:
+    """Counters are keyed by data[1] & 0x1F, which exceeds the enum."""
+
+    def test_known_command_uses_enum_name(self) -> None:
+        """Named commands still render their enum name."""
+        assert StatusMode._command_label(SerialCommand.ECHO_COMMAND.value) == (
+            "ECHO_COMMAND"
+        )
+
+    @pytest.mark.parametrize("value", [0, 1, 7, 31])
+    def test_unknown_command_renders_instead_of_raising(self, value: int) -> None:
+        """SerialCommand(value) raised ValueError and aborted the whole table."""
+        assert StatusMode._command_label(value) == f"UNKNOWN(0x{value:02X})"
+
+    def test_display_survives_unknown_command_ids(self) -> None:
+        """An arbitrary hex frame sent from Command Mode must not crash Status."""
+        sm = make_status_mode()
+        sm.ser.statistics.commands_sent = {0: 3, SerialCommand.ECHO_COMMAND.value: 1}
+        sm.ser.statistics.commands_received = {31: 2}
+
+        sm._display_statistics_status()  # must not raise

--- a/tests/test_stress_config.py
+++ b/tests/test_stress_config.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 
+import fault_frames
 from const import TEST_RESULTS_FOLDER
 from stress_config import (
     ScenarioConfig,
@@ -32,6 +33,7 @@ from stress_config import (
     default_stress_config,
     load_stress_config,
 )
+from stress_evaluator import evaluate_verdict
 
 # ---------------------------------------------------------------------------
 # Dataclass default tests
@@ -452,13 +454,15 @@ class TestLoadStressConfig:
         config_file.write_text(json.dumps({"scenarios": []}))
         cfg = load_stress_config(config_file)
         assert cfg.scenarios == []
-        assert cfg.output_dir == "results"
+        # Must match default_stress_config(); runner_cli only scans this folder.
+        assert cfg.output_dir == TEST_RESULTS_FOLDER
 
     def test_default_output_dir(self, tmp_path: Path) -> None:
         config_file = tmp_path / "no_dir.json"
         config_file.write_text(json.dumps({"scenarios": [{"name": "s"}]}))
         cfg = load_stress_config(config_file)
-        assert cfg.output_dir == "results"
+        assert cfg.output_dir == TEST_RESULTS_FOLDER
+        assert cfg.output_dir == default_stress_config().output_dir
 
     def test_file_not_found(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
@@ -484,3 +488,97 @@ class TestLoadStressConfig:
         assert cfg.scenarios[0].name == "a"
         assert cfg.scenarios[1].name == "b"
         assert cfg.scenarios[1].command_profile == "mixed"
+
+
+class TestFaultFramesFromConfig:
+    """fault_frames are named recipes, because raw bytes cannot cross JSON."""
+
+    @staticmethod
+    def _write(tmp_path: Path, scenario: dict) -> Path:
+        config_file = tmp_path / "fi.json"
+        config_file.write_text(json.dumps({"scenarios": [scenario]}))
+        return config_file
+
+    def test_named_recipes_are_resolved_to_bytes(self, tmp_path: Path) -> None:
+        """Previously frames were dropped, so the scenario injected nothing."""
+        config_file = self._write(
+            tmp_path,
+            {
+                "name": "fi",
+                "command_profile": "fault_injection",
+                "fault_frames": ["bad_checksum", "too_short"],
+            },
+        )
+        cfg = load_stress_config(config_file)
+        frames = cfg.scenarios[0].fault_frames
+
+        assert frames == [
+            fault_frames.ALL_RECIPES["bad_checksum"],
+            fault_frames.ALL_RECIPES["too_short"],
+        ]
+        assert all(isinstance(f, bytes) and f for f in frames)
+
+    def test_every_builtin_recipe_is_loadable(self, tmp_path: Path) -> None:
+        """Any recipe the module ships can be named from a config file."""
+        names = sorted(fault_frames.ALL_RECIPES)
+        config_file = self._write(
+            tmp_path,
+            {"name": "fi", "command_profile": "fault_injection", "fault_frames": names},
+        )
+        cfg = load_stress_config(config_file)
+        assert len(cfg.scenarios[0].fault_frames) == len(names)
+
+    def test_omitted_fault_frames_stays_empty(self, tmp_path: Path) -> None:
+        """Scenarios that do not inject faults are unaffected."""
+        config_file = self._write(tmp_path, {"name": "echo"})
+        assert load_stress_config(config_file).scenarios[0].fault_frames == []
+
+    def test_unknown_recipe_fails_loudly(self, tmp_path: Path) -> None:
+        """A typo must not silently produce a scenario that always FAILs."""
+        config_file = self._write(
+            tmp_path,
+            {
+                "name": "fi",
+                "command_profile": "fault_injection",
+                "fault_frames": ["bad_cheksum"],
+            },
+        )
+        with pytest.raises(ValueError, match="unknown fault frame 'bad_cheksum'"):
+            load_stress_config(config_file)
+
+    def test_non_list_fault_frames_rejected(self, tmp_path: Path) -> None:
+        """A bare string is a common mistake and is not silently accepted."""
+        config_file = self._write(
+            tmp_path,
+            {"name": "fi", "fault_frames": "bad_checksum"},
+        )
+        with pytest.raises(TypeError, match="must be a list of recipe names"):
+            load_stress_config(config_file)
+
+    def test_loaded_fault_scenario_can_meet_expected_deltas(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        The end-to-end trap: frames present means the verdict can pass.
+
+        With frames dropped, status_delta stayed empty while
+        expected_counter_deltas demanded 1, so the verdict was always FAIL.
+        """
+        config_file = self._write(
+            tmp_path,
+            {
+                "name": "fi_bad_checksum",
+                "command_profile": "fault_injection",
+                "fault_frames": ["bad_checksum"],
+                "thresholds": {
+                    "max_echo_drop_ratio": 1.0,
+                    "expected_counter_deltas": {"checksum_error": 1},
+                },
+            },
+        )
+        scenario = load_stress_config(config_file).scenarios[0]
+
+        assert scenario.fault_frames  # would have been [] before
+        verdict, reasons = evaluate_verdict(scenario, 0, 0, [], {"checksum_error": 1})
+        assert verdict == "PASS"
+        assert reasons == []

--- a/tests/test_stress_test.py
+++ b/tests/test_stress_test.py
@@ -637,13 +637,24 @@ class TestFaultInjection:
             tester._run_fault_injection(tester.config.scenarios[0])
         assert mock_serial.write_raw.call_count == 2
 
-    def test_status_snapshot_pre_and_post_per_frame(self, mock_serial: Mock) -> None:
+    def test_snapshot_reused_as_next_frames_baseline(self, mock_serial: Mock) -> None:
+        """Each frame's 'after' is the next frame's 'before': N+1, not 2N."""
         frames = [b"\x01\x00", b"\x01\x00", b"\x01\x00"]
         tester = self._make_fi_tester(mock_serial, frames)
         with patch("stress_test.time.sleep"):
             tester._run_fault_injection(tester.config.scenarios[0])
-        # pre + post for each of the 3 frames = 6 calls
-        assert tester._request_status_snapshot.call_count == 6
+        # 1 initial baseline + 1 post per frame = 4, down from 6.
+        assert tester._request_status_snapshot.call_count == len(frames) + 1
+
+    def test_snapshots_skip_task_requests(self, mock_serial: Mock) -> None:
+        """Only the statistics delta is consumed, so task polling is skipped."""
+        frames = [b"\x01\x00", b"\x01\x00"]
+        tester = self._make_fi_tester(mock_serial, frames)
+        with patch("stress_test.time.sleep"):
+            tester._run_fault_injection(tester.config.scenarios[0])
+        assert tester._request_status_snapshot.call_args_list
+        for call in tester._request_status_snapshot.call_args_list:
+            assert call.kwargs.get("include_tasks") is False
 
     def test_total_delta_accumulates_across_frames(self, mock_serial: Mock) -> None:
         frames = [b"\x01\x00", b"\x01\x00", b"\x01\x00"]

--- a/tests/test_stress_test.py
+++ b/tests/test_stress_test.py
@@ -33,7 +33,7 @@ from stress_config import (
     StressConfig,
     default_stress_config,
 )
-from stress_evaluator import StressRunResult
+from stress_evaluator import ScenarioResult, StressRunResult
 from stress_test import StressTest
 
 # ---------------------------------------------------------------------------
@@ -362,9 +362,9 @@ class TestNoiseAndRecovery:
             patch("stress_test.time.perf_counter", side_effect=lambda: next(counter)),
         ):
             tester._run_noise_and_recovery(cfg.scenarios[0])
-        # Verify raw write was called on the underlying serial object
-        assert mock_serial.ser.write.call_count >= 1
-        written_bytes = mock_serial.ser.write.call_args_list[0][0][0]
+        # Noise goes through write_raw so it is serialized against framed traffic
+        assert mock_serial.write_raw.call_count >= 1
+        written_bytes = mock_serial.write_raw.call_args_list[0][0][0]
         assert len(written_bytes) == 32
 
     def test_publish_called_after_noise(self, mock_serial: Mock) -> None:
@@ -635,7 +635,7 @@ class TestFaultInjection:
         tester = self._make_fi_tester(mock_serial, frames)
         with patch("stress_test.time.sleep"):
             tester._run_fault_injection(tester.config.scenarios[0])
-        assert mock_serial.ser.write.call_count == 2
+        assert mock_serial.write_raw.call_count == 2
 
     def test_status_snapshot_pre_and_post_per_frame(self, mock_serial: Mock) -> None:
         frames = [b"\x01\x00", b"\x01\x00", b"\x01\x00"]
@@ -751,3 +751,71 @@ def test_execute_test_with_options_emits_progress_events(mock_serial: Mock) -> N
 
     assert any(evt["event"] == "scenario_started" for evt in events)
     assert any(evt["event"] == "scenario_finished" for evt in events)
+
+
+class TestScenarioFailureIsolation:
+    """A single broken scenario must not discard the whole run."""
+
+    @staticmethod
+    def _two_scenario_config() -> StressConfig:
+        return StressConfig(
+            scenarios=[
+                ScenarioConfig(
+                    name="boom",
+                    duration_s=1.0,
+                    command_profile="echo_only",
+                    num_messages=1,
+                ),
+                ScenarioConfig(
+                    name="fine",
+                    duration_s=1.0,
+                    command_profile="echo_only",
+                    num_messages=1,
+                ),
+            ]
+        )
+
+    def test_raising_scenario_becomes_fail_and_run_continues(
+        self, mock_serial: Mock
+    ) -> None:
+        """Previously the exception aborted before the report was written."""
+        tester = _make_tester(mock_serial, self._two_scenario_config())
+        real_runner = tester._run_scenario
+
+        def flaky(cfg: ScenarioConfig) -> ScenarioResult:
+            if cfg.name == "boom":
+                msg = "device exploded"
+                raise RuntimeError(msg)
+            return real_runner(cfg)
+
+        with (
+            patch.object(tester, "_run_scenario", side_effect=flaky),
+            patch("stress_test.write_json_report") as write_report,
+            patch("stress_test.print_summary"),
+            patch("stress_test.time.sleep"),
+        ):
+            result = tester.execute_test_with_options()
+
+        assert result is not None
+        # Both scenarios are represented, not just the one that survived.
+        assert [s.name for s in result.scenarios] == ["boom", "fine"]
+        failed = result.scenarios[0]
+        assert failed.verdict == "FAIL"
+        assert "RuntimeError" in failed.failure_reasons[0]
+        assert "device exploded" in failed.failure_reasons[0]
+        assert result.overall_verdict == "FAIL"
+        # The report is still persisted despite the failure.
+        write_report.assert_called_once()
+
+    def test_interactive_and_headless_share_one_implementation(
+        self, mock_serial: Mock
+    ) -> None:
+        """execute_test and execute_test_with_options must not drift apart."""
+        tester = _make_tester(mock_serial, self._two_scenario_config())
+        with (
+            patch.object(tester, "_execute_scenarios") as run,
+            patch.object(tester, "_show_options", return_value=[]),
+        ):
+            tester.execute_test()
+            tester.execute_test_with_options()
+        assert run.call_count == 2

--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -442,7 +442,10 @@ def test_plot_error_counter_details(visualize_results: VisualizeResults) -> None
         visualize_results.plot_error_counter_details(labels, error_counters)
 
         # --- Verify Figure ---
-        mock_figure.assert_called_with(figsize=(14, 10))
+        # assert_any_call, not assert_called_with: pyplot's gcf() lazily calls
+        # figure() again from tight_layout/subplots_adjust, so the figsize call
+        # is not necessarily the last one.
+        mock_figure.assert_any_call(figsize=(14, 10))
         mock_fig.suptitle.assert_called_with(
             "Detailed Error Counter Analysis - Before/After Test Series",
             fontsize=14,

--- a/tests/test_visualize_results.py
+++ b/tests/test_visualize_results.py
@@ -706,6 +706,23 @@ def test_get_test_files(visualize_results: VisualizeResults) -> None:
         assert files == mock_files
 
 
+def test_get_test_files_excludes_runner_summaries(
+    visualize_results: VisualizeResults,
+) -> None:
+    """Test that _get_test_files ignores runner summary JSON files."""
+    mock_files = [
+        Path("20260426-103550-2783840a-latency.json"),
+        Path("20260426-103720-37ec50b4-runner.json"),
+        Path("20260426-104000-12345678-stress.json"),
+    ]
+    with patch("visualize_results.Path.glob", return_value=mock_files):
+        files = visualize_results._get_test_files()
+        assert files == [
+            Path("20260426-103550-2783840a-latency.json"),
+            Path("20260426-104000-12345678-stress.json"),
+        ]
+
+
 def test_get_page_files(visualize_results: VisualizeResults) -> None:
     """Test for the _get_page_files method."""
     files = [Path(f"test_{i}.json") for i in range(15)]


### PR DESCRIPTION
Audit of src/ surfaced four bugs that abort a run today, three unguarded
shared-state mutations across threads, and several places where one
exception discards an entire run or hangs a headless process.

Correctness:
- latency_test: num_times=1 raised ZeroDivisionError computing the wait
  ramp (j / (num_times - 1)); the ramp now degenerates to a single point.
- latency_test: the sample-count guard used `<= 0 and < MAX_SAMPLE_SIZE`,
  making the upper bound unreachable, so samples >= 65536 reached publish()
  and overflowed the two-byte counter. Fixed the operator and moved
  validation into main_test() so the headless entry points share it.
- status_mode: SerialCommand(k).name raised ValueError for any command id
  outside the five-member enum, though counters are keyed by data[1] & 0x1F
  (0-31). Unknown ids now render as UNKNOWN(0xNN).
- base_test: boolean prompts cast via bool("False"), which is True, so
  jitter and default-baud-rates could not be turned off. Booleans are now
  parsed by word, and an unconvertible entry falls back to the default
  instead of aborting the mode.

Thread safety:
- Added _latency_lock plus _latency_snapshot()/_reset_latency(); copying
  the latency dicts while a late echo arrived could raise "dictionary
  changed size during iteration". All test modes use the accessors.
- SerialStatistics owns a lock and exposes snapshot(); status_mode and the
  runner heartbeat no longer iterate the live counter dicts.
- SerialInterface.write()/write_raw() share _write_lock so concurrent
  producers cannot interleave bytes mid-frame.

Resilience:
- write() catches SerialTimeoutException and SerialException (write_timeout
  is 0, so a full output buffer surfaces as an exception) instead of
  letting them abort the caller's publish loop.
- A stress scenario that raises is recorded as a FAIL result and the run
  continues, so the report is still written; execute_test and
  execute_test_with_options now share one _execute_scenarios implementation.
- status_poll_storm applies the _MIN_GAP_S floor like the other profiles.
- close() joins with a timeout and skips unstarted threads, which otherwise
  raised RuntimeError and could hang runner_cli's finally block.
- command_mode survives undecodable frames and truncated key/analog frames
  instead of silently killing its display thread.
- Receive and display queues are bounded; the read thread sheds frames
  rather than blocking on a stalled consumer.
- Receive-path checksum verification added behind verify_checksum
  (default off) with a checksum_mismatches counter, since it is unsettled
  whether firmware replies carry a checksum.

Docs updated per CLAUDE.md: ARCHITECTURE.md documents the new locks and
accessors; dotnet_integration.md covers the new heartbeat counters, the
scenario-failure behavior change, and the checksum gap.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AEsgGFuK7PbaNRDUQbnJQ7